### PR TITLE
Fix GrpcServer.ip return type upon error

### DIFF
--- a/ansys/dpf/core/server_types.py
+++ b/ansys/dpf/core/server_types.py
@@ -691,7 +691,7 @@ class GrpcServer(CServer):
         try:
             return self.info["server_ip"]
         except:
-            return 0
+            return ""
 
     @property
     def port(self):


### PR DESCRIPTION
Should return an empty string upon exception, and not 0.