### PR TITLE
Fix idle docker entry tests

### DIFF
--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -174,12 +174,14 @@ jobs:
             pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=../tests/junit/test-results9.xml test_service/.
 
       - name: "Test API Entry"
-        shell: bash
-        working-directory: tests
-        run: |
-          cd entry
-          pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=junit/test-results10.xml  .
-        if: always()
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 3
+          max_attempts: 2
+          shell: bash
+          command: |
+            cd tests/entry
+            pytest $DEBUG $COVERAGE --cov-append $RERUNS --junitxml=junit/test-results10.xml  .
 
       - name: "Upload Test Results"
         uses: actions/upload-artifact@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "tqdm",
     "numpy",
     "ansys-dpf-gate>=0.3.*",
+    "grpcio<=1.49"
 ]
 
 [project.optional-dependencies]

--- a/src/ansys/dpf/core/model.py
+++ b/src/ansys/dpf/core/model.py
@@ -416,7 +416,7 @@ class Metadata:
             result_info = op.get_output(0, types.result_info)
         except Exception as e:
             # give the user a more helpful error
-            if "results file is not defined in the Data sources" in e.args():
+            if "results file is not defined in the Data sources" in e.args:
                 raise RuntimeError("Unable to open result file") from None
             else:
                 raise e


### PR DESCRIPTION
Apparently an issue with the later `grpcio>1.39` being unstable?
Trying to set `grpcio<=1.49`.
See 
https://github.com/grpc/grpc/issues/31885#issuecomment-1398789898 for current thread on 
https://github.com/ray-project/ray/issues/31729 for similar to us

See mapdl not testing above grpcio==1.35 https://github.com/pyansys/pymapdl/blob/687e761b8b418a052ef7cd48f432cedd2d7c8347/pyproject.toml#L25

See here for several additional runs of the test_docker pipeline with the fix:
https://github.com/pyansys/pydpf-core/actions/runs/4540844712