### PR TITLE
Retro 232 tests use available dev wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
       python_versions: '["3.8"]'
       DOCSTRING: false
       standalone_suffix: ''
-      custom-wheels: ${{ github.event.inputs.custom-wheels || './dpf-standalone/v232/dist --pre' }}
+      custom-wheels: './dpf-standalone/v232/dist --pre'
     secrets: inherit
 
   retro_231:


### PR DESCRIPTION
Tests were not using the dev wheels shipped with dpf-standalone 232 branches by default.