### PR TITLE
Improve AvailableResult.__repr__()

### DIFF
--- a/src/ansys/dpf/core/available_result.py
+++ b/src/ansys/dpf/core/available_result.py
@@ -146,6 +146,9 @@ class AvailableResult:
                 txt += f"  {qualifier.__dict__()}\n"
         return txt
 
+    def __repr__(self):
+        return f"AvailableResult<name={self.name}>"
+
     @property
     def name(self):
         """Result operator."""

--- a/tests/test_resultinfo.py
+++ b/tests/test_resultinfo.py
@@ -72,7 +72,14 @@ def test_get_result_resultinfo_from_index(model):
 
 
 def test_print_result_info(model):
-    print(model.metadata.result_info)
+    str(model.metadata.result_info)
+
+
+def test_repr_available_results_list(model):
+    ar = model.metadata.result_info.available_results
+    assert type(ar) is list
+    assert all([type(r) is dpf.core.result_info.available_result.AvailableResult for r in ar])
+    assert dpf.core.result_info.available_result.AvailableResult.__name__ in str(ar)
 
 
 @pytest.mark.skipif(platform.system() == "Linux", reason="CFF not available for Linux InProcess.")


### PR DESCRIPTION
This allows to have a nicer list of AvailableResult objects when requesting `model.metadata.result_info.available_results`:
`[AvailableResult<name=enthalpy>, AvailableResult<name=mass_flow_rate>, AvailableResult<name=static_pressure>, AvailableResult<name=mean_static_pressure>, AvailableResult<name=rms_static_pressure>]`