### PR TITLE
Fix issues with PyVista 0.41.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,7 @@ pyvista.set_error_output_file("errors.txt")
 pyvista.OFF_SCREEN = True
 # Preferred plotting style for documentation
 # pyvista.set_plot_theme('document')
-pyvista.rcParams["window_size"] = np.array([1024, 768]) * 2
+pyvista.global_theme.window_size = np.array([1024, 768]) * 2
 # Save figures in specified directory
 pyvista.FIGURE_PATH = os.path.join(os.path.abspath("./images/"), "auto-generated/")
 if not os.path.exists(pyvista.FIGURE_PATH):

--- a/requirements/requirements_docs.txt
+++ b/requirements/requirements_docs.txt
@@ -5,7 +5,7 @@ imageio-ffmpeg==0.4.7
 nbsphinx==0.9.1
 pypandoc==1.10
 pytest-sphinx==0.5.0
-pyvista==0.36.1
+pyvista==0.41.0
 sphinx==5.3.0
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.0

--- a/requirements/requirements_docs.txt
+++ b/requirements/requirements_docs.txt
@@ -5,7 +5,7 @@ imageio-ffmpeg==0.4.7
 nbsphinx==0.9.1
 pypandoc==1.10
 pytest-sphinx==0.5.0
-pyvista==0.41.0
+pyvista==0.36.1
 sphinx==5.3.0
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.0

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -4,4 +4,4 @@ pytest==7.2.0
 pytest-cov==4.0.0
 pytest-order==1.0.1
 pytest-rerunfailures==11.0
-pyvista==0.36.1
+pyvista==0.41.0

--- a/src/ansys/dpf/core/settings.py
+++ b/src/ansys/dpf/core/settings.py
@@ -32,10 +32,10 @@ def set_default_pyvista_config():
     if module_exists("pyvista"):
         import pyvista as pv
 
-        pv.rcParams["interactive"] = True
-        pv.rcParams["cmap"] = "jet"
-        pv.rcParams["font"]["family"] = "courier"
-        pv.rcParams["title"] = "DPF"
+        pv.global_theme.interactive = True
+        pv.global_theme.cmap = "jet"
+        pv.global_theme.font.family = "courier"
+        pv.global_theme.title = "DPF"
 
 
 def bypass_pv_opengl_osmesa_crash():


### PR DESCRIPTION
Hotfix for PyVista 0.41.0 released this morning.

This apparently removed the deprecated `pv.rcParams` we were still using and is breaking all our pipeline runs.

Still having an issue (which I never managed to reproduce locally neither on Windows not on Linux) with doc generation on GitHub though, requiring `pyvista==0.36.1`:

![image](https://github.com/ansys/pydpf-core/assets/100710998/1daf3dac-7e7f-43eb-b0d9-5c9f6ab091c3)
