### PR TITLE
PyDPF-Core tests on release are not requirements

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -180,7 +180,7 @@ jobs:
   draft_release:
     name: "Draft Release"
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    needs: [style, tests, docs, examples, retro_232, retro_231, retro_222, retro_221, gate, pydpf-post_241, pydpf-post_232, pydpf-post_231, pydpf-post_222, pydpf-post_221, docker_tests]
+    needs: [style, tests, docs, examples, retro_232, retro_231, retro_222, retro_221, gate, docker_tests]
     runs-on: ubuntu-latest
     steps:
       - name: "Set up Python"


### PR DESCRIPTION
Setting pydpf-post checks with the latest published pydpf-post as requirements for release creates a loop preventing us from releasing pydpf-core.
We still test whether a pydpf-post release will be necessary, but it does not prevent from releasing ansys-dpf-core.