### PR TITLE
Restrict protobof<4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "ansys-api-platform-instancemanagement<1.0.0b4",
+    "ansys-api-platform-instancemanagement<=1.0.0b3",
     "ansys-dpf-gate>=0.3.0",
     "importlib-metadata >=4.0",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    "ansys-api-platform-instancemanagement<1.0.0b4",
     "ansys-dpf-gate>=0.3.0",
     "importlib-metadata >=4.0",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,11 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "ansys-api-platform-instancemanagement<=1.0.0b3",
     "ansys-dpf-gate>=0.3.0",
     "importlib-metadata >=4.0",
     "numpy",
     "packaging",
+    "protobuf<4",
     "psutil",
     "setuptools",
     "tqdm",

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -1,4 +1,3 @@
-ansys-api-platform-instancemanagement==1.0.0b3
 ansys-platform-instancemanagement==1.1.1
 coverage==7.2.7
 imageio==2.28.0

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -1,4 +1,4 @@
-ansys-api-platform-instancemanagement==1.0.0b4
+ansys-api-platform-instancemanagement==1.0.0b3
 ansys-platform-instancemanagement==1.1.1
 coverage==7.2.7
 imageio==2.28.0

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -1,4 +1,5 @@
-ansys-platform-instancemanagement==1.0.2
+ansys-api-platform-instancemanagement==1.0.0b4
+ansys-platform-instancemanagement==1.1.1
 coverage==7.2.7
 imageio==2.28.0
 imageio-ffmpeg==0.4.7


### PR DESCRIPTION
The lastest failures in the CI have been attributed to `ansys-api-plaftorm-instancemanagement==1.0.0b4` because it removed the pin on `protobuf<4`.
Also, `ansys-platform-instancemanagement==1.0.2` was pinned in `requirements_test.txt` but not to the latest.
This PR updates to `ansys-platform-instancemanagement==1.1.1` and tests if forcing `ansys-api-plaftorm-instancemanagement==1.0.0b3` temporarily solves our issues.

When using all latest pypim libraries and forcing `protobuf<4`: [it passes ](https://github.com/ansys/pydpf-core/actions/runs/5795021862/job/15705936037#step:15:85)
