### PR TITLE
Add links for doc and cheat sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![cov](https://codecov.io/gh/ansys/pydpf-core/branch/master/graph/badge.svg)](https://codecov.io/gh/ansys/pydpf-core)
 [![codacy](https://app.codacy.com/project/badge/Grade/61b6a519aea64715ad1726b3955fcf98)](https://www.codacy.com/gh/ansys/pydpf-core/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ansys/pydpf-core&amp;utm_campaign=Badge_Grade)
 
-The Data Processing Framework (DPF) provides numerical simulation 
+Ansys Data Processing Framework (DPF) provides numerical simulation 
 users and engineers with a toolbox for accessing and transforming simulation 
 data. With DPF, you can perform complex preprocessing or postprocessing of
 large amounts of simulation data within a simulation workflow.
@@ -27,8 +27,8 @@ The latest version of DPF supports Ansys solver result files for:
 - Fluent (`.cas/dat.h5`, `.flprj`)
 - CFX (`.cad/dat.cff`, `.flprj`)
 
-See the `PyDPF-Core main page <https://dpf.docs.pyansys.com/version/stable/index.html>`_
-for more information on compatibility.
+For more information on compatibility, see the `main page <https://dpf.docs.pyansys.com/version/stable/index.html>`_
+of the PDF-Core documentation.
 
 Using the many DPF operators that are available, you can manipulate and
 transform this data. You can also chain operators together to create simple
@@ -47,12 +47,30 @@ The ``ansys.dpf.core`` package provides a Python interface to DPF, enabling
 rapid postprocessing of a variety of Ansys file formats and physics solutions
 without ever leaving the Python environment.
 
-## Documentation
+## Documentation and issues
 
-Visit the [DPF-Core Documentation](https://dpfdocs.pyansys.com) for
-comprehensive information on this library. See the
-[Examples](https://dpfdocs.pyansys.com/version/stable/examples/index.html)
-for how-to information.
+Documentation for the latest stable release of PyPDF-Core is hosted at
+[DPF-Core documentation](https://dpf.docs.pyansys.com/version/stable/).
+
+In the upper right corner of the documentation's title bar, there is an option for switching from
+viewing the documentation for the latest stable release to viewing the documentation for the
+development version or previously released versions.
+
+In the upper right corner of the documentation's title bar, there is an option for switching from
+viewing the documentation for the latest stable release to viewing the documentation for the
+development version or previously released versions.
+
+You can also [view](https://cheatsheets.docs.pyansys.com/pydpf-core_cheat_sheet.png>`_ or
+[download](https://cheatsheets.docs.pyansys.com/pydpf-core_cheat_sheet.pdf) the
+PyDPF-Core cheat sheet. This one-page reference provides syntax rules and commands
+for using PyDPF-Core.
+
+On the [PyDPF-Core Issues](https://github.com/ansys/pydpf-core/issues) page,
+you can create issues to report bugs and request new features. On the
+[PyDPF-Core Discussions](https://github.com/ansys/pydpf-core/discussions) page or the {Discussions](https://discuss.ansys.com/)
+page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
+
+To reach the project support team, email [pyansys.core@ansys.com](mailto:pyansys.core@ansys.com).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In the upper right corner of the documentation's title bar, there is an option f
 viewing the documentation for the latest stable release to viewing the documentation for the
 development version or previously released versions.
 
-You can also [view](https://cheatsheets.docs.pyansys.com/pydpf-core_cheat_sheet.png>`_ or
+You can also [view](https://cheatsheets.docs.pyansys.com/pydpf-core_cheat_sheet.png) or
 [download](https://cheatsheets.docs.pyansys.com/pydpf-core_cheat_sheet.pdf) the
 PyDPF-Core cheat sheet. This one-page reference provides syntax rules and commands
 for using PyDPF-Core.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -153,6 +153,28 @@ It is independent of the Ansys installer.
 
 - `C++ solver reader plugin <https://astonishing-hyacinth-e64.notion.site/How-to-write-a-new-solver-reader-as-a-DPF-s-plugin-bd2d2a3cf51f47ef9e70df45d64f89cb>`_
 
+Documentation and issues
+------------------------
+Documentation for the latest stable release of PyDPF-Core is hosted at `PyDPF-Core documentation
+<https://dpf.docs.pyansys.com/version/stable/>`_.
+
+In the upper right corner of the documentation's title bar, there is an option for switching from
+viewing the documentation for the latest stable release to viewing the documentation for the
+development version or previously released versions.
+
+You can also `view <https://cheatsheets.docs.pyansys.com/pydpf-core_cheat_sheet.png>`_ or
+`download <https://cheatsheets.docs.pyansys.com/pydpf-core_cheat_sheet.pdf>`_ the
+PyDPF-Core cheat sheet. This one-page reference provides syntax rules and commands
+for using PyDPF-Core. 
+
+On the `PyDPF-Core Issues <https://github.com/ansys/pydpf-core/issues>`_ page,
+you can create issues to report bugs and request new features. On the `PyDPF-Core Discussions
+<https://github.com/ansys/pydpf-core/discussions>`_ page or the `Discussions <https://discuss.ansys.com/>`_
+page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
+
+To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
+
+
 - :ref:`user_guide_custom_operators`
 
 


### PR DESCRIPTION
Per Landon’s request in the PyAnsys Global AFT on 7/26/23, add links to the PyDPF-Core cheat sheet from this library's documentation.

Note: This library doesn't reuse the README content in the overall index.rst file for documentation. Consequently, I revised the "Documentation and issues" sections in both the README and the overall index.rst file.