### PR TITLE
Do not run doctest for retro PyDPF-Post

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -122,6 +122,7 @@ jobs:
     with:
       ANSYS_VERSION: "241"
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
+      test_docstrings: "true"
     secrets: inherit
 
   pydpf-post_232:

--- a/.github/workflows/pydpf-post.yml
+++ b/.github/workflows/pydpf-post.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: ''
+      test_docstrings:
+        description: "whether to run doctest"
+        required: false
+        type: string
+        default: "false"
 # Can be called manually
   workflow_dispatch:
     inputs:
@@ -53,6 +58,11 @@ on:
         required: false
         type: string
         default: ''
+      test_docstrings:
+        description: "whether to run doctest"
+        required: false
+        type: string
+        default: "false"
 
 env:
   PACKAGE_NAME: ansys-dpf-core
@@ -141,6 +151,7 @@ jobs:
           MODULE: post
           PACKAGE_NAME: ansys-dpf-post
           working-directory: pydpf-post/src
+        if: inputs.test_docstrings = 'true'
 
       - name: "Test API"
         shell: bash


### PR DESCRIPTION
Running the docstrings for previous server versions is not supported/tested/ensured in the PyDPF-Post CI, meaning it should not be run here either. 