### PR TITLE
Fix some bad formatting and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ apps for both data input and data output, including visualization and
 result plots. It can access data from solver result files and other neutral
 formats, such as CSV, HDF5, and VTK files.
 
-The latest version of DPF supports Ansys solver result files for:
+The latest version of DPF supports Ansys solver results files for:
 
-- MAPDL (`.rst`, `.mode`, `.rfrq`, `.rdsp`)
+- Mechanical APDL (`.rst`, `.mode`, `.rfrq`, `.rdsp`)
 - LS-DYNA (`.d3plot`, `.binout`)
 - Fluent (`.cas/dat.h5`, `.flprj`)
 - CFX (`.cad/dat.cff`, `.flprj`)
 
-For more information on compatibilities, see the [main page](https://dpf.docs.pyansys.com/version/stable/index.html)
+For more information on file support, see the [main page](https://dpf.docs.pyansys.com/version/stable/index.html)
 in the PDF-Core documentation.
 
 Using the many DPF operators that are available, you can manipulate and
@@ -172,9 +172,10 @@ module. It closes when you exit Python or connect to a different server.
 
 ## License and acknowledgments
 
-PyDPF-Core is licensed under the MIT license.
+PyDPF-Core is licensed under the MIT license. For more information, see the
+[LICENSE](https://github.com/ansys/pydpf-post/raw/master/LICENSE) file.
 
 PyDPF-Core makes no commercial claim over Ansys whatsoever. This library
 extends the functionality of Ansys DPF by adding a Python interface
-to Ansys DPF without changing the core behavior or license of the original
+to DPF without changing the core behavior or license of the original
 software.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ The latest version of DPF supports Ansys solver result files for:
 - Fluent (`.cas/dat.h5`, `.flprj`)
 - CFX (`.cad/dat.cff`, `.flprj`)
 
-For more information on compatibility, see the `main page <https://dpf.docs.pyansys.com/version/stable/index.html>`_
-of the PDF-Core documentation.
+For more information on compatibilities, see the [main page](https://dpf.docs.pyansys.com/version/stable/index.html)
+in the PDF-Core documentation.
 
 Using the many DPF operators that are available, you can manipulate and
 transform this data. You can also chain operators together to create simple
@@ -37,11 +37,9 @@ future evaluations.
 
 The data in DPF is defined based on physics-agnostic mathematical quantities 
 described in self-sufficient entities called **fields**. This allows DPF to be 
-a modular and easy-to-use tool with a large range of capabilities. 
+a modular and easy-to-use tool with a large range of capabilities.
 
-.. image:: https://github.com/ansys/pydpf-core/raw/main/docs/source/images/drawings/dpf-flow.png
-  :width: 670
-  :alt: DPF flow
+![DPF flow](https://github.com/ansys/pydpf-core/raw/main/docs/source/images/drawings/dpf-flow.png "DPF flow")
 
 The ``ansys.dpf.core`` package provides a Python interface to DPF, enabling
 rapid postprocessing of a variety of Ansys file formats and physics solutions
@@ -50,7 +48,7 @@ without ever leaving the Python environment.
 ## Documentation and issues
 
 Documentation for the latest stable release of PyPDF-Core is hosted at
-[DPF-Core documentation](https://dpf.docs.pyansys.com/version/stable/).
+[PyDPF-Core documentation](https://dpf.docs.pyansys.com/version/stable/).
 
 In the upper right corner of the documentation's title bar, there is an option for switching from
 viewing the documentation for the latest stable release to viewing the documentation for the
@@ -67,7 +65,7 @@ for using PyDPF-Core.
 
 On the [PyDPF-Core Issues](https://github.com/ansys/pydpf-core/issues) page,
 you can create issues to report bugs and request new features. On the
-[PyDPF-Core Discussions](https://github.com/ansys/pydpf-core/discussions) page or the {Discussions](https://discuss.ansys.com/)
+[PyDPF-Core Discussions](https://github.com/ansys/pydpf-core/discussions) page or the [Discussions](https://discuss.ansys.com/)
 page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
 
 To reach the project support team, email [pyansys.core@ansys.com](mailto:pyansys.core@ansys.com).
@@ -76,7 +74,8 @@ To reach the project support team, email [pyansys.core@ansys.com](mailto:pyansys
 
 PyDPF-Core requires DPF to be available. You can either have a compatible Ansys version installed
 or install the standalone ``ansys-dpf-server`` server package. For more information, see
-[Getting Started with DPF Server](https://dpf.docs.pyansys.com/version/stable/user_guide/getting_started_with_dpf_server.html) in the PyDPF-Core documentation.
+[Getting Started with DPF Server](https://dpf.docs.pyansys.com/version/stable/user_guide/getting_started_with_dpf_server.html)
+in the PyDPF-Core documentation.
 
 For the compatibility between PyDPF-Core and Ansys, see
 [Compatibility](https://dpf.docs.pyansys.com/version/stable/getting_started/compatibility.html) in
@@ -174,3 +173,12 @@ remote or local DPF instance, use the ``connect_to_server`` method:
 
 Once connected, this connection remains for the duration of the
 module. It closes when you exit Python or connect to a different server.
+
+## License and acknowledgments
+
+PyDPF-Core is licensed under the MIT license.
+
+PyDPF-Core makes no commercial claim over Ansys whatsoever. This library
+extends the functionality of Ansys DPF by adding a Python interface
+to Ansys DPF without changing the core behavior or license of the original
+software.

--- a/README.md
+++ b/README.md
@@ -54,10 +54,6 @@ In the upper right corner of the documentation's title bar, there is an option f
 viewing the documentation for the latest stable release to viewing the documentation for the
 development version or previously released versions.
 
-In the upper right corner of the documentation's title bar, there is an option for switching from
-viewing the documentation for the latest stable release to viewing the documentation for the
-development version or previously released versions.
-
 You can also [view](https://cheatsheets.docs.pyansys.com/pydpf-core_cheat_sheet.png) or
 [download](https://cheatsheets.docs.pyansys.com/pydpf-core_cheat_sheet.pdf) the
 PyDPF-Core cheat sheet. This one-page reference provides syntax rules and commands

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,7 +42,7 @@ apps by DPF and their related format:
 |                    || .flprj                |                                  |                                  |
 +--------------------+------------------------+----------------------------------+----------------------------------+
 
-Visualisation is ensured by VTK and leverage of `PyVista tools
+Visualisation is ensured by VTK and leverages `PyVista tools
 <https://docs.pyvista.org>`_.
 
 Using the many DPF operators that are available, you can manipulate and
@@ -112,46 +112,51 @@ Accessing and enriching DPF capabilities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Most of the DPF capabilities can be accessed using the operators.
-For more information about the existing operators, see the **Operators** tab.
+For more informations, see :ref:`_ref_dpf_operators_reference`.
 
-The following sections are summaries. For more detailed content, see :ref:`user_guide_waysofusing`.
+The following sections are summaries. For more information, see :ref:`user_guide_waysofusing`.
 
 **Accessing DPF Server files**
 
-DPF capabilities are accessible when DPF Server files are available. These files can be accessed using:
+DPF capabilities are accessible when DPF Server files are available. These files can be accessed using
+the **Ansys installer** and **DPF Server**.
 
-- The **Ansys installer**. To use it, download the standard installation using your preferred distribution channel,
-and install Ansys following the installer instructions. For information on getting a licensed copy of Ansys,
-visit the `Ansys website <https://www.ansys.com/>`_.
+- To use the Ansys installer, download the standard Ansys installation using your preferred
+  distribution channel, and install Ansys following the installer instructions. For information
+  on getting a licensed copy of Ansys, visit the `Ansys website <https://www.ansys.com/>`_.
 
-- The DPF Server package (see :ref:`ref_getting_started_with_dpf_server`).
-It is independent of the Ansys installer.
+- The DPF Server package is independent of the Ansys installer. For more information, see
+  :ref:`ref_getting_started_with_dpf_server`.
 
 **Accessing capabilities with scripting**
 
 - C++ documentation:
 
-  1. The Data Processing Framework section in `Platform panel <https://ansysapi.ansys.com/account/secured?returnurl=/Views/Secured/main_page.html?lang=en>`_.
+  - On the `Developer Documentation <https://developer.ansys.com/docs>`_page of the Ansys Developer portal,
+    see **Data Processing Framework (DPF)**.
 
-  2. The Data Processing Framework section in `Developer Portal <https://developer.ansys.com/docs>`_
+- PyDPF documentation:
 
-- CPython modules documentation:
+  - `PyDPF-Core documentation <https://dpf.docs.pyansys.com/version/stable/>`_
 
-  1. `ansys-dpf-core <https://dpf.docs.pyansys.com/version/stable/>`_
-
-  2. `ansys-dpf-post <https://post.docs.pyansys.com/version/stable/>`_
+  - `PyDPF-Post documentation <https://post.docs.pyansys.com/version/stable/>`_
 
 - Mechanical scripting (IronPython):
 
-  1. `DPF through Automation Scripting <https://ansysproducthelpdev.win.ansys.com/account/secured?returnurl=/Views/Secured/corp/v231/en/act_script/mech_apis_data_process_frame.html>`_
-
-  2. `Python Result object <https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/corp/v231/en/wb_sim/ds_python_result.html>`_
+  - `Data Processing Framework <https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/corp/v232/en/act_script/mech_apis_data_process_frame.html>`_
+    in the *Scripting in Mechanical Guide*.
+  
+  - `Python Result <https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/corp/v231/en/wb_sim/ds_python_result.html>`_
+    in the *Mechanical User's Guide*.
 
 **Enriching DPF capabilities**
 
-- C++ operator's library (see "DPF/USER GUIDE" section of `C++ documentation <https://developer.ansys.com/docs>`_)
+- `User guide <https://developer.ansys.com/product/DPF-C-Client-Library-2023-R2/modules.xhtml>`_ in the *DPF C++ Client Library*
 
-- `C++ solver reader plugin <https://astonishing-hyacinth-e64.notion.site/How-to-write-a-new-solver-reader-as-a-DPF-s-plugin-bd2d2a3cf51f47ef9e70df45d64f89cb>`_
+- :ref:`user_guide_custom_operators` in the PyDPF-Core documentation 
+
+- `How to write a new solver reader as a PDF's plugin <https://astonishing-hyacinth-e64.notion.site/How-to-write-a-new-solver-reader-as-a-DPF-s-plugin-bd2d2a3cf51f47ef9e70df45d64f89cb>`_
+
 
 Documentation and issues
 ------------------------
@@ -173,9 +178,6 @@ you can create issues to report bugs and request new features. On the `PyDPF-Cor
 page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
 
 To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
-
-
-- :ref:`user_guide_custom_operators`
 
 
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -112,7 +112,7 @@ Accessing and enriching DPF capabilities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Most of the DPF capabilities can be accessed using the operators.
-For more informations, see :ref:`_ref_dpf_operators_reference`.
+For more information, see :ref:`_ref_dpf_operators_reference`.
 
 The following sections are summaries. For more information, see :ref:`user_guide_waysofusing`.
 
@@ -155,7 +155,7 @@ the **Ansys installer** and **DPF Server**.
 
 - :ref:`user_guide_custom_operators` in the PyDPF-Core documentation 
 
-- `How to write a new solver reader as a PDF's plugin <https://astonishing-hyacinth-e64.notion.site/How-to-write-a-new-solver-reader-as-a-DPF-s-plugin-bd2d2a3cf51f47ef9e70df45d64f89cb>`_
+- `How to write a new solver reader as a PDF plugin <https://astonishing-hyacinth-e64.notion.site/How-to-write-a-new-solver-reader-as-a-DPF-s-plugin-bd2d2a3cf51f47ef9e70df45d64f89cb>`_
 
 
 Documentation and issues

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,7 +4,7 @@
 PyDPF-Core
 ==========
 
-The Data Processing Framework (DPF) provides numerical simulation 
+Ansys Data Processing Framework (DPF) provides numerical simulation 
 users and engineers with a toolbox for accessing and transforming simulation 
 data. With DPF, you can perform complex preprocessing or postprocessing of
 large amounts of simulation data within a simulation workflow.
@@ -12,7 +12,7 @@ large amounts of simulation data within a simulation workflow.
 DPF is an independent, physics-agnostic tool that you can plug into many 
 apps for both data input and data output, including visualization and 
 result plots. The following table shows an exhaustive list of supported
-apps by DPF and their related format:
+apps by DPF and their related formats:
 
 .. table:: Truth table for "not"
    :widths: auto


### PR DESCRIPTION
@PProfizi and @anslpa  There were some format errors and broken links on the README and overall index pages. I cleaned both pages up. I will also soon be adding cheat sheet links for PyPDF-Post and cleaning up these same two files in that repo.