### PR TITLE
Update compatibility for 2023R2 and 2024R1.pre1

### DIFF
--- a/docs/source/getting_started/compatibility.rst
+++ b/docs/source/getting_started/compatibility.rst
@@ -42,10 +42,15 @@ should also be synchronized with the server version.
      - ``ansys.grpc.dpf`` Python module version
      - ``ansys.dpf.core`` Python module version
    * - 7.0 (Ansys 2024 R1 pre0)
-     - 0.4.0 and later
-     - 0.4.0 and later
-     - 0.8.0 and later
+     - 0.4.1 and later
+     - 0.4.1 and later
+     - 0.8.1 and later
      - 0.9.0 and later
+   * - 6.2 (Ansys 2023 R2)
+     - 0.3.1 and later
+     - 0.3.1 and later
+     - 0.7.1 and later
+     - 0.8.0 and later
    * - 6.1 (Ansys 2023 R2 pre1)
      - 0.3.1 and later
      - 0.3.1 and later


### PR DESCRIPTION
Ansys 2023R2 was missing and library minimal versions required for Ansys 2024R1.pre1 must be the patched ".1" versions as the initial ones were yanked.