### PR TITLE
minimum dpf version is `0.4.0` and not 4.0

### DIFF
--- a/examples/08-python-operators/02-python_operators_with_dependencies.py
+++ b/examples/08-python-operators/02-python_operators_with_dependencies.py
@@ -19,7 +19,7 @@ and then exports the mesh and the norm of the 3D vector field to a GLTF
 file at the given path.
 
 .. note::
-    This example requires DPF 4.0 (Ansys 2022R2) or above.
+    This example requires DPF 0.4.0 (Ansys 2022R2) or above.
     For more information, see :ref:`ref_compatibility`.
 
 """


### PR DESCRIPTION
the version number noted in example was wrong
![image](https://github.com/ansys/pydpf-core/assets/82146655/5721a099-69db-4c71-ae24-be5dfc1dc3e1)
