### PR TITLE
Revert "Fix bug 843531 - DPF: Access violation when DataSource is incorrectly constructed"

### DIFF
--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -18,8 +18,7 @@ from ansys.dpf.gate import (
 )
 
 from ansys.dpf.core.check_version import version_requires
-from ansys.grpc.dpf import data_sources_pb2
-from ansys.dpf.core import errors
+
 
 class DataSources:
     """Contains files with analysis results.
@@ -78,12 +77,9 @@ class DataSources:
                 self._internal_obj = core_api.data_processing_duplicate_object_reference(
                     data_sources
                 )
-            elif isinstance(data_sources, data_sources_pb2.DataSources) or isinstance(data_sources, int):
+            else:
                 # It should be a message (usually from a call to operator_getoutput_data_sources)
                 self._internal_obj = data_sources
-            else:
-                self._internal_obj = None
-                raise errors.DpfValueError("Data source must be gRPC data sources message type")
         else:
             if self._server.has_client():
                 self._internal_obj = self._api.data_sources_new_on_client(self._server.client)

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -61,9 +61,6 @@ def test_print_data_sources(allkindofcomplexity, server_type):
 
 
 def test_data_sources_from_data_sources(allkindofcomplexity, server_type):
-    with pytest.raises(ValueError) as e:
-        data_sources_false = dpf.core.DataSources(data_sources="Wrong Input", server=server_type)
-        assert "Data source must be gRPC data sources message type" in e
     data_sources = dpf.core.DataSources(server=server_type)
     data_sources2 = dpf.core.DataSources(data_sources=data_sources, server=server_type)
 


### PR DESCRIPTION
Reverts ansys/pydpf-core#1139