### PR TITLE
Allow 10 PRs for dependabot pip updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     insecure-external-code-execution: allow
     schedule:
       interval: "daily"
+    # Allow up to 10 open pull requests for pip dependencies
+    open-pull-requests-limit: 10
     labels:
       - "maintenance"
       - "dependencies"


### PR DESCRIPTION
Dependabot alerts were not triggering since August 11th due to 5 PRs in progress.
Bumped the number to 10 so we can see more.
This for example prevented us from updating `ansys-sphinx-theme`, which would have prevented an issue #1144.