### PR TITLE
Update 03-fluids_isosurface.py

### DIFF
--- a/examples/12-fluids/03-fluids_isosurface.py
+++ b/examples/12-fluids/03-fluids_isosurface.py
@@ -7,7 +7,7 @@ Compute iso-surfaces on fluid models
 This example demonstrates how to compute iso-surfaces on fluid models.
 
 .. note::
-    This example requires DPF 7.0 (ansys-dpf-server-2024-1-pre0) or above.
+    This example requires DPF 7.1 (ansys-dpf-server-2024-1-pre1) or above.
     For more information, see :ref:`ref_compatibility`.
 
 """


### PR DESCRIPTION
See error only when run on Linux here 
https://github.com/ansys/pydpf-core/actions/runs/6496374240/job/17643189569#step:14:3636

See here for ref on master 
https://github.com/ansys/pydpf-core/actions/runs/6251477896

At first I thought it was a problem of the example requiring 7.0 instead of 7.1 but it does not explain why it works on Windows runners... I have to check the CI

Edit: conclusion is that the last update to the example using operator iso_surfaces is not compatible with DPF 7.0, so we need to revert the example to its original state.