### PR TITLE
Vale check modified only and ignore roles

### DIFF
--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -26,6 +26,6 @@ jobs:
           files: docs
           reporter: ${{ inputs.vale_reporter || 'local' }}
           level: error
-          filter_mode: nofilter
+          filter_mode: added
           fail_on_error: true
           vale_flags: "--config=docs/.vale.ini"

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -16,8 +16,6 @@ SkippedScopes = script, style, pre, figure
 # WordTemplate specifies what Vale will consider to be an individual word.
 WordTemplate = \b(?:%s)\b
 
-TokenIgnores = (:class:`.*`)
-
 # List of Packages to be used for our guidelines
 Packages = Google
 
@@ -32,3 +30,13 @@ BasedOnStyles = Vale, Google
 # Removing Google-specific rule - Not applicable under some circumstances
 Google.WordList = NO
 Google.Colons = NO
+
+[formats]
+# Format associations appear under
+# the optional "formats" section.
+
+[*]
+# Format-specific settings appear
+# under a user-provided "glob"
+# pattern.
+TokenIgnores = (:class:`.*`)

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -39,4 +39,4 @@ Google.Colons = NO
 # Format-specific settings appear
 # under a user-provided "glob"
 # pattern.
-TokenIgnores = (:class:`.*`)
+TokenIgnores = (:class:\x60.*\x60|:meth:\x60.*\x60)

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -16,6 +16,8 @@ SkippedScopes = script, style, pre, figure
 # WordTemplate specifies what Vale will consider to be an individual word.
 WordTemplate = \b(?:%s)\b
 
+TokenIgnores = (:class:`.*`)
+
 # List of Packages to be used for our guidelines
 Packages = Google
 

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -39,4 +39,4 @@ Google.Colons = NO
 # Format-specific settings appear
 # under a user-provided "glob"
 # pattern.
-TokenIgnores = (:class:\x60.*\x60|:meth:\x60.*\x60)
+TokenIgnores = (:class:\x60.*\x60|:meth:\x60.*\x60|:py:class:\x60.*\x60|:py:meth:\x60.*\x60)

--- a/docs/source/user_guide/operators.rst
+++ b/docs/source/user_guide/operators.rst
@@ -279,9 +279,8 @@ This example instantiates operators with other operators:
     min_max = ops.min_max.min_max(displacement)
 
 This automatically connects the matching ``displacement`` output with the 
-matching ``min_max`` input. You can also use the :py:meth:`connect()
-<ansys.dpf.core.dpf_operator.Operator.connect>` method to manually connect 
-the outputs of one operator to the inputs of another operator:
+matching ``min_max`` input. You can also use the :py:meth:`connect()<ansys.dpf.core.dpf_operator.Operator.connect>`
+method to manually connect the outputs of one operator to the inputs of another operator:
 
 .. code-block:: python
 


### PR DESCRIPTION
Stops Vale from complaining and failing, which it has been doing for a few days, most likely due to an update somewhere.