### PR TITLE
Fix static operators documentation embedding

### DIFF
--- a/docs/source/operator_reference_load.rst
+++ b/docs/source/operator_reference_load.rst
@@ -9,10 +9,11 @@ Loading operators.
 .. raw:: html
 
     <iframe
+      title="DPF Operators"
       src="_static/dpf_operators.html#CPython"
       style="
         position: fixed;
-        top: 36px;
+        top: 50px;
         bottom: 0px;
         right: 0px;
         width: 100%;
@@ -21,6 +22,6 @@ Loading operators.
         padding: 0;
         overflow: hidden;
         z-index: 1000;
-        height: 100%;
+        height: 95%;
       ">
     </iframe>

--- a/docs/source/operator_reference_load.rst
+++ b/docs/source/operator_reference_load.rst
@@ -22,6 +22,6 @@ Loading operators.
         padding: 0;
         overflow: hidden;
         z-index: 1000;
-        height: 95%;
+        height: 94%;
       ">
     </iframe>


### PR DESCRIPTION
The current parameters for the embedding of the static doc prevents from scrolling to the actual bottom of the doc.

I tested these parameters from within Chrome and they look good.