### PR TITLE
Revert Vale filter to nofilter

### DIFF
--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -26,6 +26,6 @@ jobs:
           files: docs
           reporter: ${{ inputs.vale_reporter || 'local' }}
           level: error
-          filter_mode: added
+          filter_mode: nofilter
           fail_on_error: true
           vale_flags: "--config=docs/.vale.ini"


### PR DESCRIPTION
Limiting to `added` is not working when the CI runs on a merge commit on master when the diff is empty on files targeted by Vale.