### PR TITLE
Make test_resultinfo.py retrocompatible with DPF 7.0

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -290,6 +290,9 @@ def cfx_mixing_elbow():
     return return_ds
 
 
+SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_1 = meets_version(
+    get_server_version(core._global_server()), "7.1"
+)
 SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_0 = meets_version(
     get_server_version(core._global_server()), "7.0"
 )

--- a/tests/test_resultinfo.py
+++ b/tests/test_resultinfo.py
@@ -5,6 +5,7 @@ from ansys.dpf.core import Model
 from conftest import (
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_5_0,
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_0,
+    SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_1,
 )
 
 if SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_5_0:
@@ -25,7 +26,7 @@ def test_get_resultinfo_no_model(velocity_acceleration, server_type):
     op.connect(4, dataSource)
     res = op.get_output(0, dpf.core.types.result_info)
     assert res.analysis_type == "static"
-    if not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_0:
+    if not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_1:
         assert res.n_results == 14
     else:
         assert res.n_results == 15
@@ -36,7 +37,7 @@ def test_get_resultinfo_no_model(velocity_acceleration, server_type):
 def test_get_resultinfo(model):
     res = model.metadata.result_info
     assert res.analysis_type == "static"
-    if not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_0:
+    if not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_1:
         assert res.n_results == 14
     else:
         assert res.n_results == 15


### PR DESCRIPTION
The update of `test_resultinfo.py` made following an update in the result file reference did not filter for DPF 7.1 but for DPF 7.0, which is wrong.

Before:
https://github.com/ansys/pydpf-core/actions/runs/6496374240/job/17643178410#logs
After:
https://github.com/ansys/pydpf-core/actions/runs/6496892196