### PR TITLE
Refactor version handling

### DIFF
--- a/src/ansys/dpf/core/_version.py
+++ b/src/ansys/dpf/core/_version.py
@@ -8,16 +8,6 @@ __version__ = ".".join(map(str, version_info))
 # Minimal DPF server version supported
 min_server_version = "4.0"
 
-server_to_ansys_grpc_dpf_version = {
-    "1.0": "==0.2.2",
-    "2.0": "==0.3.0",
-    "3.0": ">=0.4.0",
-    "4.0": ">=0.5.0",
-    "5.0": ">=0.6.0",
-    "6.0": ">=0.7.0",
-    "7.0": ">=0.8dev",
-}
-
 
 class ServerToAnsysVersion:
     legacy_version_map = {

--- a/src/ansys/dpf/core/_version.py
+++ b/src/ansys/dpf/core/_version.py
@@ -4,6 +4,8 @@ version_info = 0, 9, 1, "dev0"
 
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))
+
+# Minimal DPF server version supported
 min_server_version = "4.0"
 
 server_to_ansys_grpc_dpf_version = {

--- a/src/ansys/dpf/core/_version.py
+++ b/src/ansys/dpf/core/_version.py
@@ -4,7 +4,7 @@ version_info = 0, 9, 1, "dev0"
 
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))
-min_server_version = "2.0"
+min_server_version = "4.0"
 
 server_to_ansys_grpc_dpf_version = {
     "1.0": "==0.2.2",
@@ -16,15 +16,27 @@ server_to_ansys_grpc_dpf_version = {
     "7.0": ">=0.8dev",
 }
 
-server_to_ansys_version = {
-    "1.0": "2021R1",
-    "2.0": "2021R2",
-    "3.0": "2022R1",
-    "4.0": "2022R2",
-    "5.0": "2023R1",
-    "6.0": "2023R2",
-    "6.1": "2023R2",
-    "6.2": "2023R2",
-    "7.0": "2024R1",
-    "7.1": "2024R1",
-}
+
+class ServerToAnsysVersion:
+    legacy_version_map = {
+        "1.0": "2021R1",
+        "2.0": "2021R2",
+        "3.0": "2022R1",
+        "4.0": "2022R2",
+        "5.0": "2023R1",
+        "6.0": "2023R2",
+        "6.1": "2023R2",
+        "6.2": "2023R2",
+        "7.0": "2024R1",
+        "7.1": "2024R1",
+    }
+
+    def __getitem__(self, item):
+        if len(item) == 3:
+            return self.legacy_version_map[item]
+        else:
+            split = item.split('.')
+            return split[0]+'R'+split[1]
+
+
+server_to_ansys_version = ServerToAnsysVersion()

--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -339,7 +339,7 @@ def check_ansys_grpc_dpf_version(server, timeout):
         )
     LOG.debug("Established connection to DPF gRPC")
     if version.parse(server.version) < version.parse(min_server_version):
-        raise ValueError(f"Error connecting via gRPC to DPF server version {server.version} "
+        raise ValueError(f"Error connecting to DPF LegacyGrpcServer with version {server.version} "
                          f"(ANSYS {server_to_ansys_version[server.version]}): "
                          f"ansys-dpf-core {__version__} does not support DPF servers below "
                          f"{min_server_version} ({server_to_ansys_version[min_server_version]}).")

--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -21,8 +21,9 @@ import ansys.dpf.core as core
 from ansys.dpf.core.check_version import server_meet_version
 from ansys.dpf.core import errors, server_factory
 from ansys.dpf.core._version import (
-    server_to_ansys_grpc_dpf_version,
+    min_server_version,
     server_to_ansys_version,
+    __version__
 )
 from ansys.dpf.core import server_context
 from ansys.dpf.gate import load_api, data_processing_grpcapi
@@ -323,7 +324,6 @@ def _compare_ansys_grpc_dpf_version(right_grpc_module_version_str: str, grpc_mod
 
 
 def check_ansys_grpc_dpf_version(server, timeout):
-    import ansys.grpc.dpf
     import grpc
 
     state = grpc.channel_ready_future(server.channel)
@@ -336,37 +336,12 @@ def check_ansys_grpc_dpf_version(server, timeout):
         raise TimeoutError(
             f"Failed to connect to {server._input_ip}:{server._input_port} in {timeout} seconds"
         )
-    compatibility_link = (
-        f"https://dpf.docs.pyansys.com/getting_started/" f"index.html#client-server-compatibility"
-    )
     LOG.debug("Established connection to DPF gRPC")
-    grpc_module_version = ansys.grpc.dpf.__version__
-    server_version = server.version
-    right_grpc_module_version = server_to_ansys_grpc_dpf_version.get(server_version, None)
-    if right_grpc_module_version is None:  # pragma: no cover
-        # warnings.warn(f"No requirement specified on ansys-grpc-dpf for server version "
-        #               f"{server_version}. Continuing with the ansys-grpc-dpf version "
-        #               f"installed ({grpc_module_version}). In case of unexpected instability, "
-        #               f"please refer to the compatibility guidelines given in "
-        #               f"{compatibility_link}.")
-        return
-    if not _compare_ansys_grpc_dpf_version(right_grpc_module_version, grpc_module_version):
-        ansys_version_to_use = server_to_ansys_version.get(server_version, "Unknown")
-        ansys_versions = core._version.server_to_ansys_version
-        latest_ansys = ansys_versions[max(ansys_versions.keys())]
-        raise ImportWarning(
-            f"An incompatibility has been detected between the DPF server version "
-            f"({server_version} "
-            f"from Ansys {ansys_version_to_use})"
-            f" and the ansys-grpc-dpf version installed ({grpc_module_version})."
-            f" Please consider using the latest DPF server available in the "
-            f"{latest_ansys} Ansys unified install.\n"
-            f"To follow the compatibility guidelines given in "
-            f"{compatibility_link} while still using DPF server {server_version}, "
-            f"please install version {right_grpc_module_version} of ansys-grpc-dpf"
-            f" with the command: \n"
-            f"     pip install ansys-grpc-dpf{right_grpc_module_version}"
-        )
+    if server.version < min_server_version:
+        raise ValueError(f"Error connecting via gRPC to DPF server version {server.version} "
+                         f"(ANSYS {server_to_ansys_version[server.version]}): "
+                         f"ansys-dpf-core {__version__} does not support DPF servers below "
+                         f"{min_server_version} ({server_to_ansys_version[min_server_version]}).")
 
 
 class GhostServer:

--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -325,6 +325,7 @@ def _compare_ansys_grpc_dpf_version(right_grpc_module_version_str: str, grpc_mod
 
 def check_ansys_grpc_dpf_version(server, timeout):
     import grpc
+    from packaging import version
 
     state = grpc.channel_ready_future(server.channel)
     # verify connection has matured
@@ -337,7 +338,7 @@ def check_ansys_grpc_dpf_version(server, timeout):
             f"Failed to connect to {server._input_ip}:{server._input_port} in {timeout} seconds"
         )
     LOG.debug("Established connection to DPF gRPC")
-    if server.version < min_server_version:
+    if version.parse(server.version) < version.parse(min_server_version):
         raise ValueError(f"Error connecting via gRPC to DPF server version {server.version} "
                          f"(ANSYS {server_to_ansys_version[server.version]}): "
                          f"ansys-dpf-core {__version__} does not support DPF servers below "

--- a/tests/test_checkversion.py
+++ b/tests/test_checkversion.py
@@ -97,3 +97,9 @@ def test_find_outdated_ansys_version():
     assert _find_outdated_ansys_version(arg5) == False
     assert _find_outdated_ansys_version(arg6) == False
     assert _find_outdated_ansys_version(arg7) == True
+
+
+def test_version():
+    from ansys.dpf.core._version import server_to_ansys_version
+    assert server_to_ansys_version["1.0"] == "2021R1"
+    assert server_to_ansys_version["2099.9"] == "2099R9"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -288,3 +288,25 @@ def test_start_after_shutting_down_server():
     info = remote_server.info
     remote_server.shutdown()
     assert info is not None
+
+
+def test_check_ansys_grpc_dpf_version_raise():
+    remote_server = start_local_server(
+        config=dpf.core.AvailableServerConfigs.LegacyGrpcServer, as_global=False
+    )
+
+    class MockServer:
+        def __init__(self, server):
+            for attribute in ["channel", "_input_ip", "_input_port"]:
+                setattr(self, attribute, getattr(server, attribute))
+
+        @property
+        def version(self):
+            return "1.0"
+
+    print(MockServer(remote_server).version)
+    with pytest.raises(
+            ValueError,
+            match="Error connecting to DPF LegacyGrpcServer with version 1.0"
+    ):
+        dpf.core.server_types.check_ansys_grpc_dpf_version(MockServer(remote_server), timeout=2.0)


### PR DESCRIPTION
This PR proposes a refactor of `ansys.dpf.core._version.py`'s `server_to_ansys_version` to enable handling `XXXX.Y.Z` DPF versioning while retaining retro-compatibility.
It also removes `server_to_ansys_grpc_dpf_version` as `ansys.grpc.dpf` is now shipped within `ansys-dpf-core`.
Instead, what is checked when connecting to a server via gRPC is whether the DPF server we try to connect to has a version at least equal to the `min_server_version` variable, which is the minimal DPF version supported by the current `ansys-dpf-core` package.