### PR TITLE
Fix path management for PyInstaller

### DIFF
--- a/src/ansys/dpf/core/__init__.py
+++ b/src/ansys/dpf/core/__init__.py
@@ -9,8 +9,8 @@ LOCAL_DOWNLOADED_EXAMPLES_PATH = None
 try:
     import pkgutil
 
-    spec = pkgutil.get_loader("ansys.dpf.core")
-    USER_DATA_PATH = os.path.dirname(spec.get_filename())
+    spec = pkgutil.get_loader(__name__)
+    USER_DATA_PATH = os.path.dirname(spec.get_filename(__name__))
     if not os.path.exists(USER_DATA_PATH):  # pragma: no cover
         os.makedirs(USER_DATA_PATH)
 


### PR DESCRIPTION
Use __name__ argument to get the correct USER_DATA_PATH when in PyInstaller.
Closes #1216