### PR TITLE
Update compatibility and dependencies for 0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ To install PyDPF-Core with its optional plotting functionalities, use this comma
 
 For more information on PyDPF-Core plotting capabilities, see [Plot](https://dpf.docs.pyansys.com/version/stable/user_guide/plotting.html) in the PyDPF-Core documentation.
 
-To use PyDPF-Core with Ansys 2022R1, install the latest compatible version
+To use PyDPF-Core with Ansys 2022 R1, install the latest compatible version
 with this command:
 
 ```con
    pip install ansys-dpf-core<0.10.0
 ```
 
-To use PyDPF-Core with Ansys 2021R2, install the latest compatible version
+To use PyDPF-Core with Ansys 2021 R2, install the latest compatible version
 with this command:
 
 ```con

--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ To use PyDPF-Core with Ansys 2021R2, install the latest compatible version
 with this command:
 
 ```con
-   pip install ansys-dpf-core<0.10.0; pip install ansys-grpc-dpf<0.4.0
+   pip install ansys-grpc-dpf<0.4.0; pip install ansys-dpf-core<0.10.0
 ```
 
 To use PyDPF-Core with Ansys 2021 R1, install the latest compatible version
 with this command:
 
 ```con
-   pip install ansys-dpf-core<0.3.0; pip install ansys-grpc-dpf<0.3.0
+   pip install ansys-grpc-dpf<0.3.0; pip install ansys-dpf-core<0.3.0
 ```
 
 ### Brief demo

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For the compatibility between PyDPF-Core and Ansys, see
 [Compatibility](https://dpf.docs.pyansys.com/version/stable/getting_started/compatibility.html) in
 the PyDPF-Core documentation.
 
-To use PyDPF-Core with the ``ansys-dpf-server`` server package or with Ansys 2021 R2 or later, 
+To use PyDPF-Core with the ``ansys-dpf-server`` server package or with Ansys 2022 R2 or later, 
 install the latest version with this command:
 
 ```con
@@ -93,11 +93,25 @@ To install PyDPF-Core with its optional plotting functionalities, use this comma
 
 For more information on PyDPF-Core plotting capabilities, see [Plot](https://dpf.docs.pyansys.com/version/stable/user_guide/plotting.html) in the PyDPF-Core documentation.
 
-To use PyDPF-Core with Ansys 2021 R1, install the latest version
+To use PyDPF-Core with Ansys 2022R1, install the latest compatible version
 with this command:
 
 ```con
-   pip install ansys-dpf-core<0.3.0
+   pip install ansys-dpf-core<0.10.0
+```
+
+To use PyDPF-Core with Ansys 2021R2, install the latest compatible version
+with this command:
+
+```con
+   pip install ansys-dpf-core<0.10.0; pip install ansys-grpc-dpf<0.4.0
+```
+
+To use PyDPF-Core with Ansys 2021 R1, install the latest compatible version
+with this command:
+
+```con
+   pip install ansys-dpf-core<0.3.0; pip install ansys-grpc-dpf<0.3.0
 ```
 
 ### Brief demo

--- a/docs/source/getting_started/compatibility.rst
+++ b/docs/source/getting_started/compatibility.rst
@@ -33,8 +33,8 @@ and prevent synchronization issues between the PyDPF libraries, requiring to dro
 previous to 2022 R2.
 
 **Ansys strongly encourages you to use the latest packages available**, as far they are compatible
-with the Server version you want to use. Using Ansys 2023 R1 for example, if ansys-dpf-core
-module with 0.10.0 version is the latest available package, it should be used.
+with the Server version you want to run. Considering Ansys 2023 R1 for example, if ansys-dpf-core
+module with 0.10.0 version is the latest available compatible package, it should be used.
 
 For ``ansys-dpf-core<0.10``, the `ansys.grpc.dpf <https://pypi.org/project/ansys-grpc-dpf/>`_
 package should also be synchronized with the server version.

--- a/docs/source/getting_started/compatibility.rst
+++ b/docs/source/getting_started/compatibility.rst
@@ -15,84 +15,115 @@ Client-server
 
 The DPF server version depends on your installed Ansys version.
 The following table shows client-server compatibility for supported
-Ansys versions. With Ansys 2021 R2 and later, you can use PyDPF-Core
-version 0.3.0 or later. With Ansys 2021 R1, you must use a PyDPF-Core 0.2
+Ansys versions. With Ansys 2022 R2 and later, you can use PyDPF-Core ``0.10`` and later.
+With Ansys 2021 R2 and 2022 R1, you can use PyDPF-Core
+version ``0.3`` up to ``0.9``. With Ansys 2021 R1, you must use a PyDPF-Core ``0.2``
 version.
 
 As new features are developed, every attempt is made to ensure backward
-compatibility from the client to the server. Backward compatibility is ensured for
+compatibility from the client to the server. Backward compatibility is generally ensured for
 the 4 latest Ansys versions. For example, ansys-dpf-core module with 0.8.0 version has been
 developed for Ansys 2023 R2 pre1 release, for 2023 R2 Ansys version. It is compatible with
 2023 R2, 2023 R1, 2022 R2 and 2022 R1 Ansys versions.
 
-**Ansys strongly encourages you to use the latest packages available**, as far they are compatible
-with the Server version you want to use. Using Ansys 2022 R2, if ansys-dpf-core module with
-0.8.0 version is the latest available package, it should be used.
+Starting with version ``0.10`` of ``ansys-dpf-core``, the packages ``ansys-dpf-gate``,
+``ansys-dpf-gatebin`` and ``ansys-grpc-dpf`` are no longer dependencies and are directly integrated
+within ``ansys-dpf-core`` as modules. This introduced a breaking change to simplify installation
+and prevent synchronization issues between the PyDPF libraries, requiring to drop support for Ansys
+previous to 2022 R2.
 
-The `ansys.grpc.dpf <https://pypi.org/project/ansys-grpc-dpf/>`_ package
-should also be synchronized with the server version.
+**Ansys strongly encourages you to use the latest packages available**, as far they are compatible
+with the Server version you want to use. Using Ansys 2023 R1 for example, if ansys-dpf-core
+module with 0.10.0 version is the latest available package, it should be used.
+
+For ``ansys-dpf-core<0.10``, the `ansys.grpc.dpf <https://pypi.org/project/ansys-grpc-dpf/>`_
+package should also be synchronized with the server version.
 
 .. list-table:: Client-server compatibility
    :widths: 20 20 20 20 20
    :header-rows: 1
 
    * - Server version
+     - ``ansys.dpf.core`` Python module version
+     - ``ansys.grpc.dpf`` Python module version
      - ``ansys.dpf.gatebin`` binaries Python module version
      - ``ansys.dpf.gate`` Python module version
-     - ``ansys.grpc.dpf`` Python module version
-     - ``ansys.dpf.core`` Python module version
    * - 7.0 (Ansys 2024 R1 pre0)
-     - 0.4.1 and later
-     - 0.4.1 and later
-     - 0.8.1 and later
-     - 0.9.0 and later
+     - | 0.10.0 and later
+       | 0.9.0
+     - | None
+       | 0.8.1
+     - | None
+       | 0.4.1
+     - | None
+       | 0.4.1
    * - 6.2 (Ansys 2023 R2)
-     - 0.3.1 and later
-     - 0.3.1 and later
-     - 0.7.1 and later
-     - 0.8.0 and later
+     - | 0.10.0 and later
+       | 0.8.0 and later
+     - | None
+       | 0.7.1 and later
+     - | None
+       | 0.3.1 and later
+     - | None
+       | 0.3.1 and later
    * - 6.1 (Ansys 2023 R2 pre1)
-     - 0.3.1 and later
-     - 0.3.1 and later
-     - 0.7.1 and later
-     - 0.8.0 and later
+     - | 0.10.0 and later
+       | 0.8.0 and later
+     - | None
+       | 0.7.1 and later
+     - | None
+       | 0.3.1 and later
+     - | None
+       | 0.3.1 and later
    * - 6.0 (Ansys 2023 R2 pre0)
-     - 0.3.0 and later
-     - 0.3.0 and later
-     - 0.7.0 and later
-     - 0.7.0 and later
+     - | 0.10.0 and later
+       | 0.7.0 and later
+     - | None
+       | 0.7.0 and later
+     - | None
+       | 0.3.0 and later
+     - | None
+       | 0.3.0 and later
    * - 5.0 (Ansys 2023 R1)
-     - 0.2.0 and later
-     - 0.2.0 and later
-     - 0.6.0 and later
-     - 0.6.0 and later
+     - | 0.10.0 and later
+       | 0.6.0 and later
+     - | None
+       | 0.6.0 and later
+     - | None
+       | 0.2.0 and later
+     - | None
+       | 0.2.0 and later
    * - 4.0 (Ansys 2022 R2)
-     - 0.1.0 and later
-     - 0.1.0 and later
-     - 0.5.0 and later
-     - 0.5.0 and later
+     - | 0.10.0 and later
+       | 0.5.0 and later
+     - | None
+       | 0.5.0 and later
+     - | None
+       | 0.1.0 and later
+     - | None
+       | 0.1.0 and later
    * - 3.0 (Ansys 2022 R1)
-     - None
-     - None
+     - 0.4.0 to 0.9.0
      - 0.4.0
-     - 0.4.0 and later
+     - None
+     - None
    * - 2.0 (Ansys 2021 R2)
-     - None
-     - None
-     - 0.3.0
      - 0.3.0 and later**
+     - 0.3.0
+     - None
+     - None
    * - 1.0 (Ansys 2021 R1)
-     - None
-     - None
-     - 0.2.2
      - 0.2.*
+     - 0.2.2
+     - None
+     - None
 
-(** Compatibility of DPF 2.0 with ansys-dpf-core 0.5.0 and later is assumed but no longer certified.)
+(** Compatibility of DPF 2.0 with ansys-dpf-core 0.5.0 to 0.9.0 is assumed but not certified.)
 
 Update Python environment
 -------------------------
 
-When moving from one Ansys release to another, you must update the ``ansys-dpf-core`` package and its dependencies.
+When moving from one Ansys release to another, you must update the ``ansys-dpf-core`` package.
 To get the latest version of the ``ansys-dpf-core`` package, use this command:
 
 .. code::

--- a/docs/source/getting_started/dependencies.rst
+++ b/docs/source/getting_started/dependencies.rst
@@ -8,20 +8,28 @@ Package dependencies
 --------------------
 
 Dependencies for the ``ansys-dpf-core`` package are automatically checked when the
-package is installed. Package dependencies follow:
+package is installed. Package dependencies are:
+
+- `google-api-python-client <https://pypi.org/project/google-api-python-client/>`_
+- `grpcio <https://pypi.org/project/grpcio/>`_
+- `importlib-metadata <https://pypi.org/project/importlib-metadata/>`_
+- `numpy <https://pypi.org/project/numpy/>`_
+- `packaging <https://pypi.org/project/packaging/>`_
+- `protobuf <https://pypi.org/project/protobuf/>`_
+- `psutil <https://pypi.org/project/psutil/>`_
+- `setuptools <https://pypi.org/project/setuptools/>`_
+- `tqdm <https://pypi.org/project/tqdm/>`_
+
+For ``ansys-dpf-core<0.10.0``, the ``ansys.dpf.gate``, ``ansys.dpf.gatebin`` and ``ansys.grpc.dpf``
+modules are not included and are dependencies:
 
 - `ansys.dpf.gate <https://pypi.org/project/ansys-dpf-gate/>`_, which is the gate
   to the DPF C API or Python gRPC API. The gate depends on the server configuration:
+- `ansys.grpc.dpf <https://pypi.org/project/ansys-grpc-dpf/>`_ is the gRPC code
+  generated from protobuf files and is a dependency of ``ansys-dpf-gate``.
+- `ansys.dpf.gatebin <https://pypi.org/project/ansys-dpf-gatebin/>`_ is the
+  operating system-specific binaries with DPF C APIs and is a dependency of ``ansys-dpf-gate``.
 
-    - `ansys.grpc.dpf <https://pypi.org/project/ansys-grpc-dpf/>`_ is the gRPC code
-      generated from protobuf files.
-    - `ansys.dpf.gatebin <https://pypi.org/project/ansys-dpf-gatebin/>`_ is the
-      operating system-specific binaries with DPF C APIs.
-
-- `psutil <https://pypi.org/project/psutil/>`_
-- `tqdm <https://pypi.org/project/tqdm/>`_
-- `packaging <https://pypi.org/project/packaging/>`_
-- `numpy <https://pypi.org/project/numpy/>`_
 
 Optional dependencies
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -9,7 +9,7 @@ Install using ``pip``
 
 The standard package installer for Python is `pip <https://pypi.org/project/pip/>`_.
 
-To use PyDPF-Core with Ansys 2021 R2 or later, install the latest version
+To use PyDPF-Core with Ansys 2022 R2 or later, install the latest version
 with this command:
 
 .. code::
@@ -25,12 +25,26 @@ To install PyDPF-Core with its optional plotting functionalities, use:
 
 For more information about PyDPF-Core plotting capabilities, see :ref:`user_guide_plotting`.
 
-To use PyDPF-Core with Ansys 2021 R1, install the latest version
+To use PyDPF-Core with Ansys 2022 R1, install the latest compatible version
 with this command:
 
 .. code::
 
-   pip install ansys-dpf-core<0.3.0
+   pip install ansys-dpf-core<0.10.0
+
+To use PyDPF-Core with Ansys 2021 R2, install the latest compatible version
+with this command:
+
+.. code::
+
+   pip install ansys-grpc-dpf<0.4.0; pip install ansys-dpf-core<0.10.0
+
+To use PyDPF-Core with Ansys 2021 R1, install the latest compatible version
+with this command:
+
+.. code::
+
+   pip install ansys-grpc-dpf<0.3.0; pip install ansys-dpf-core<0.3.0
 
 
 Install without internet

--- a/docs/source/user_guide/troubleshooting.rst
+++ b/docs/source/user_guide/troubleshooting.rst
@@ -35,7 +35,7 @@ Assume that you are importing the ``pydpf-core`` package:
     from ansys.dpf import core as dpf
 
 If an error lists missing modules, see :ref:`ref_compatibility`.
-The `ansys.grpc.dpf <https://pypi.org/project/ansys-grpc-dpf/>`_ module
+For ``pydpf-core``<0.10.0, the `ansys.grpc.dpf <https://pypi.org/project/ansys-grpc-dpf/>`_ module
 should always be synchronized with its server version.
 
 Model issues

--- a/docs/source/user_guide/troubleshooting.rst
+++ b/docs/source/user_guide/troubleshooting.rst
@@ -28,14 +28,14 @@ on the network.
 
 Import the ``pydpf-core`` package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Assume that you are importing the ``pydpf-core`` package:
+Assume that you are importing the ``PyDPF-Core`` package:
 
 .. code-block:: default
 
     from ansys.dpf import core as dpf
 
 If an error lists missing modules, see :ref:`ref_compatibility`.
-For ``pydpf-core``<0.10.0, the `ansys.grpc.dpf <https://pypi.org/project/ansys-grpc-dpf/>`_ module
+For ``PyDPF-Core``<0.10.0, the `ansys.grpc.dpf <https://pypi.org/project/ansys-grpc-dpf/>`_ module
 should always be synchronized with its server version.
 
 Model issues

--- a/docs/styles/Vocab/ANSYS/accept.txt
+++ b/docs/styles/Vocab/ANSYS/accept.txt
@@ -11,6 +11,7 @@ Gaussian
 getters
 gltf
 GLTF
+grpcio
 hexa
 IronPython
 matplotlib
@@ -33,6 +34,7 @@ Reusability
 Rz
 scopings
 serializer
+setuptools
 substep
 tqdm
 von


### PR DESCRIPTION
TLDR; `ansys-dpf-gate`, `ansys-dpf-gatebin`, and `ansys-grpc-dpf` no longer exist as separate packages. They are now directly shipped within `ansys-dpf-core` as modules. This PR changes the doc (mainly the compatibility table) accordingly.

Closes #1214 