### PR TITLE
Only update the dev doc when pushing onto master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
 
   upload-development-docs:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
     needs: [docs]
     steps:
       - name: "Upload development documentation"


### PR DESCRIPTION
and not just when running the CI on master
Noticed that behavior when running a regular CI on master during a server update.