### PR TITLE
Fix units case in available result

### DIFF
--- a/src/ansys/dpf/core/available_result.py
+++ b/src/ansys/dpf/core/available_result.py
@@ -186,7 +186,7 @@ class AvailableResult:
     @property
     def unit(self):
         """Unit of the result."""
-        return self._unit.lower()
+        return self._unit
 
     @property
     def operator_name(self):

--- a/tests/test_resultinfo.py
+++ b/tests/test_resultinfo.py
@@ -100,7 +100,7 @@ Operator name: "CP"
 Number of components: 1
 Dimensionality: scalar
 Homogeneity: specific_heat
-Units: j/kg*k^-1
+Units: J/kg*K^-1
 Location: Nodal
 Available qualifier labels:"""  # noqa: E501
     ref2 = "'phase': 2"


### PR DESCRIPTION
Units were written in lower case for available results. This is not correct and it is also incoherent with the rest of their uses (ResultInfo and Fields, for example)