### PR TITLE
Make DataSources recognize a d3plot file without a key

### DIFF
--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -116,6 +116,10 @@ class DataSources:
         ['/tmp/file.rst']
 
         """
+        # Handle the case of files without extension, such as the LS-DYNA d3plot file
+        if os.path.splitext(filepath)[1] == "":
+            if "d3plot" in os.path.basename(filepath):
+                key = "d3plot"
         if key == "":
             self._api.data_sources_set_result_file_path_utf8(self, str(filepath))
         else:

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -42,6 +42,11 @@ def test_addfilepathspecifiedresult_data_sources(allkindofcomplexity, server_typ
     data_sources.add_file_path_for_specified_result(allkindofcomplexity, "d3plot")
 
 
+def test_setresultpath_data_sources_no_extension(d3plot_beam, server_type):
+    data_sources = dpf.core.DataSources(server=server_type)
+    data_sources.set_result_file_path(d3plot_beam)
+
+
 def test_addupstream_data_sources(allkindofcomplexity, server_type):
     data_sources = dpf.core.DataSources(server=server_type)
     data_sources2 = dpf.core.DataSources(server=server_type)


### PR DESCRIPTION
Quick proposal to enable working with `d3plot` files in PyDPF-Post. See ansys/pydpf-post#534.
I think this should eventually be implemented directly in the DPF `CDataSources`.