### PR TITLE
maint(typos): rename PDF to DPF

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The latest version of DPF supports Ansys solver results files for:
 - CFX (`.cad/dat.cff`, `.flprj`)
 
 For more information on file support, see the [main page](https://dpf.docs.pyansys.com/version/stable/index.html)
-in the DPF-Core documentation.
+in the PyDPF-Core documentation.
 
 Using the many DPF operators that are available, you can manipulate and
 transform this data. You can also chain operators together to create simple

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The latest version of DPF supports Ansys solver results files for:
 - CFX (`.cad/dat.cff`, `.flprj`)
 
 For more information on file support, see the [main page](https://dpf.docs.pyansys.com/version/stable/index.html)
-in the PDF-Core documentation.
+in the DPF-Core documentation.
 
 Using the many DPF operators that are available, you can manipulate and
 transform this data. You can also chain operators together to create simple
@@ -47,7 +47,7 @@ without ever leaving the Python environment.
 
 ## Documentation and issues
 
-Documentation for the latest stable release of PyPDF-Core is hosted at
+Documentation for the latest stable release of PyDPF-Core is hosted at
 [PyDPF-Core documentation](https://dpf.docs.pyansys.com/version/stable/).
 
 In the upper right corner of the documentation's title bar, there is an option for switching from

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -155,7 +155,7 @@ the **Ansys installer** and **DPF Server**.
 
 - :ref:`user_guide_custom_operators` in the PyDPF-Core documentation 
 
-- `How to write a new solver reader as a PDF plugin <https://astonishing-hyacinth-e64.notion.site/How-to-write-a-new-solver-reader-as-a-DPF-s-plugin-bd2d2a3cf51f47ef9e70df45d64f89cb>`_
+- `How to write a new solver reader as a DPF plugin <https://astonishing-hyacinth-e64.notion.site/How-to-write-a-new-solver-reader-as-a-DPF-s-plugin-bd2d2a3cf51f47ef9e70df45d64f89cb>`_
 
 
 Documentation and issues

--- a/docs/source/user_guide/custom_operators_deps.rst
+++ b/docs/source/user_guide/custom_operators_deps.rst
@@ -3,7 +3,7 @@ and reference a folder or ZIP file with the sites of the dependencies in an XML 
 located next to the folder for the plug-in package. The XML file must have the same
 name as the plug-in package plus an ``.xml`` extension.
 
-When the :py:func:`ansys.dpf.core.core.load_library` method is called, DPF-Core uses the
+When the :py:func:`ansys.dpf.core.core.load_library` method is called, PyDPF-Core uses the
 ``site`` Python module to add custom sites to the path for the Python interpreter.
 
 

--- a/docs/source/user_guide/custom_operators_deps.rst
+++ b/docs/source/user_guide/custom_operators_deps.rst
@@ -3,7 +3,7 @@ and reference a folder or ZIP file with the sites of the dependencies in an XML 
 located next to the folder for the plug-in package. The XML file must have the same
 name as the plug-in package plus an ``.xml`` extension.
 
-When the :py:func:`ansys.dpf.core.core.load_library` method is called, PDF-Core uses the
+When the :py:func:`ansys.dpf.core.core.load_library` method is called, DPF-Core uses the
 ``site`` Python module to add custom sites to the path for the Python interpreter.
 
 


### PR DESCRIPTION
Just a small mistake I found in the docs, used [rg](https://github.com/BurntSushi/ripgrep) and [rsr](https://github.com/awoimbee/rsr) to try to fix every misspelling.

BTW in this PR I'm just fixing the project name, but [typos](https://github.com/crate-ci/typos) finds a lot of mistakes, it might be a good idea to add it to your CI.
