### PR TITLE
Detect binout files automatically

### DIFF
--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -116,10 +116,16 @@ class DataSources:
         ['/tmp/file.rst']
 
         """
-        # Handle the case of files without extension, such as the LS-DYNA d3plot file
+        # Handle the case of files without extension, such as the LS-DYNA d3plot and binout files
         if os.path.splitext(filepath)[1] == "":
             if "d3plot" in os.path.basename(filepath):
                 key = "d3plot"
+            elif "binout" in os.path.basename(filepath):
+                key = "binout"
+        elif os.path.splitext(filepath)[1] == "d3plot":
+            key = "d3plot"
+        elif os.path.splitext(filepath)[1] == "binout":
+            key = "binout"
         if key == "":
             self._api.data_sources_set_result_file_path_utf8(self, str(filepath))
         else:

--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -116,16 +116,19 @@ class DataSources:
         ['/tmp/file.rst']
 
         """
-        # Handle the case of files without extension, such as the LS-DYNA d3plot and binout files
-        if os.path.splitext(filepath)[1] == "":
-            if "d3plot" in os.path.basename(filepath):
+        # Handle no key given
+        if key == "":
+            # Handle the case of files without extension, such as the LSDYNA d3plot and binout files
+            if os.path.splitext(filepath)[1] == "":
+                if "d3plot" in os.path.basename(filepath):
+                    key = "d3plot"
+                elif "binout" in os.path.basename(filepath):
+                    key = "binout"
+            # Handle LSDYNA extensions
+            elif os.path.splitext(filepath)[1] == "d3plot":
                 key = "d3plot"
-            elif "binout" in os.path.basename(filepath):
+            elif os.path.splitext(filepath)[1] == "binout":
                 key = "binout"
-        elif os.path.splitext(filepath)[1] == "d3plot":
-            key = "d3plot"
-        elif os.path.splitext(filepath)[1] == "binout":
-            key = "binout"
         if key == "":
             self._api.data_sources_set_result_file_path_utf8(self, str(filepath))
         else:

--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -127,13 +127,12 @@ class DataSources:
     @staticmethod
     def guess_result_key(filepath: str) -> str:
         """Guess result key for files without a file extension."""
-        d3plot_key = "d3plot"
-        binout_key = "binout"
+        result_keys = ["d3plot", "binout"]
+        base_name = os.path.basename(filepath)
         # Handle files without extension
-        if d3plot_key in os.path.basename(filepath):
-            return d3plot_key
-        elif binout_key in os.path.basename(filepath):
-            return binout_key
+        for result_key in result_keys:
+            if result_key in base_name:
+                return result_key
         return ""
 
     def set_domain_result_file_path(self, path, domain_id):

--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -116,23 +116,25 @@ class DataSources:
         ['/tmp/file.rst']
 
         """
-        # Handle no key given
-        if key == "":
-            # Handle the case of files without extension, such as the LSDYNA d3plot and binout files
-            if os.path.splitext(filepath)[1] == "":
-                if "d3plot" in os.path.basename(filepath):
-                    key = "d3plot"
-                elif "binout" in os.path.basename(filepath):
-                    key = "binout"
-            # Handle LSDYNA extensions
-            elif os.path.splitext(filepath)[1] == "d3plot":
-                key = "d3plot"
-            elif os.path.splitext(filepath)[1] == "binout":
-                key = "binout"
+        # Handle no key given and no file extension
+        if key == "" and os.path.splitext(filepath)[1] == "":
+            key = self.guess_result_key(str(filepath))
         if key == "":
             self._api.data_sources_set_result_file_path_utf8(self, str(filepath))
         else:
             self._api.data_sources_set_result_file_path_with_key_utf8(self, str(filepath), key)
+
+    @staticmethod
+    def guess_result_key(filepath: str) -> str:
+        """Guess result key for files without a file extension."""
+        d3plot_key = "d3plot"
+        binout_key = "binout"
+        # Handle files without extension
+        if d3plot_key in os.path.basename(filepath):
+            return d3plot_key
+        elif binout_key in os.path.basename(filepath):
+            return binout_key
+        return ""
 
     def set_domain_result_file_path(self, path, domain_id):
         """Add a result file path by domain.

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -42,9 +42,11 @@ def test_addfilepathspecifiedresult_data_sources(allkindofcomplexity, server_typ
     data_sources.add_file_path_for_specified_result(allkindofcomplexity, "d3plot")
 
 
-def test_setresultpath_data_sources_no_extension(d3plot_beam, server_type):
+def test_setresultpath_data_sources_no_extension(d3plot_beam, binout_glstat, server_type):
     data_sources = dpf.core.DataSources(server=server_type)
     data_sources.set_result_file_path(d3plot_beam)
+    data_sources = dpf.core.DataSources(server=server_type)
+    data_sources.set_result_file_path(binout_glstat)
 
 
 def test_addupstream_data_sources(allkindofcomplexity, server_type):

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -51,16 +51,6 @@ def test_setresultpath_data_sources_no_extension(d3plot_beam, binout_glstat, ser
     assert data_sources.result_key == "binout"
 
 
-def test_setresultpath_data_sources_dyna_extensions(d3plot_beam, binout_glstat, server_type):
-
-    data_sources = dpf.core.DataSources(server=server_type)
-    data_sources.set_result_file_path(d3plot_beam)
-    assert data_sources.result_key == "d3plot"
-    data_sources = dpf.core.DataSources(server=server_type)
-    data_sources.set_result_file_path(binout_glstat)
-    assert data_sources.result_key == "binout"
-
-
 def test_addupstream_data_sources(allkindofcomplexity, server_type):
     data_sources = dpf.core.DataSources(server=server_type)
     data_sources2 = dpf.core.DataSources(server=server_type)

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -45,8 +45,20 @@ def test_addfilepathspecifiedresult_data_sources(allkindofcomplexity, server_typ
 def test_setresultpath_data_sources_no_extension(d3plot_beam, binout_glstat, server_type):
     data_sources = dpf.core.DataSources(server=server_type)
     data_sources.set_result_file_path(d3plot_beam)
+    assert data_sources.result_key == "d3plot"
     data_sources = dpf.core.DataSources(server=server_type)
     data_sources.set_result_file_path(binout_glstat)
+    assert data_sources.result_key == "binout"
+
+
+def test_setresultpath_data_sources_dyna_extensions(d3plot_beam, binout_glstat, server_type):
+
+    data_sources = dpf.core.DataSources(server=server_type)
+    data_sources.set_result_file_path(d3plot_beam)
+    assert data_sources.result_key == "d3plot"
+    data_sources = dpf.core.DataSources(server=server_type)
+    data_sources.set_result_file_path(binout_glstat)
+    assert data_sources.result_key == "binout"
 
 
 def test_addupstream_data_sources(allkindofcomplexity, server_type):


### PR DESCRIPTION
Part of work for ansys/pydpf-post#534.

Improves previous PR for automatic result key for known files without extensions (d3plot and binout) 