### PR TITLE
Map int32 operator output to int

### DIFF
--- a/src/ansys/dpf/core/outputs.py
+++ b/src/ansys/dpf/core/outputs.py
@@ -56,6 +56,8 @@ class Output:
             type_output = types.vec_double
         elif type_output == "vector<int32>":
             type_output = types.vec_int
+        elif type_output == "int32":
+            type_output = types.int
 
         type_output_derive_class = self._spec.name_derived_class
 


### PR DESCRIPTION
Users trying to create Operators with int32 defined in their specs need it to be treated as an int for it to be understood by PyDPF-Core.