### PR TITLE
Update update_operators.yml to allow automatic sync

### DIFF
--- a/.github/workflows/update_operators.yml
+++ b/.github/workflows/update_operators.yml
@@ -119,6 +119,12 @@ jobs:
         run: |
           git status
 
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.CI_APP_ID }}
+          private_key: ${{ secrets.CI_APP_TOKEN }}
+
       - name: "Create Pull Request"
         uses: peter-evans/create-pull-request@v4
         with:
@@ -134,7 +140,7 @@ jobs:
           body: An update of generated code has been triggered either manually or by an update in the dpf-standalone repository.
           branch: maint/update_code_for_${{ github.event.inputs.ANSYS_VERSION || '242' }}${{ github.event.inputs.standalone_branch_suffix || '' }}_on_${{ github.ref_name }}
           labels: maintenance
-          token: secrets.CI_TOKEN
+          token: ${{ steps.generate-token.outputs.token }}
           committer: PProfizi <paul.profizi@ansys.com>
           author: PProfizi <paul.profizi@ansys.com>
 

--- a/.github/workflows/update_operators.yml
+++ b/.github/workflows/update_operators.yml
@@ -134,7 +134,7 @@ jobs:
           body: An update of generated code has been triggered either manually or by an update in the dpf-standalone repository.
           branch: maint/update_code_for_${{ github.event.inputs.ANSYS_VERSION || '242' }}${{ github.event.inputs.standalone_branch_suffix || '' }}_on_${{ github.ref_name }}
           labels: maintenance
-          token: secrets.PYANSYS_CI_BOT_TOKEN
+          token: secrets.CI_TOKEN
 
       - name: "Kill all servers"
         uses: ansys/pydpf-actions/kill-dpf-servers@v2.3

--- a/.github/workflows/update_operators.yml
+++ b/.github/workflows/update_operators.yml
@@ -4,6 +4,8 @@ on:
 # Can be called manually or remotely
   workflow_dispatch:
     inputs:
+      distinct_id:
+
       ANSYS_VERSION:
         description: "ANSYS version"
         required: false
@@ -27,6 +29,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
+      - name: echo distinct ID ${{ github.event.inputs.distinct_id }}
+        run: echo ${{ github.event.inputs.distinct_id }}
+
       - uses: actions/checkout@v3
 
       - name: Setup Python

--- a/.github/workflows/update_operators.yml
+++ b/.github/workflows/update_operators.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           git status
 
-      - uses: tibdex/github-app-token@v1
+      - uses: tibdex/github-app-token@v2
         id: generate-token
         with:
           app_id: ${{ secrets.CI_APP_ID }}

--- a/.github/workflows/update_operators.yml
+++ b/.github/workflows/update_operators.yml
@@ -144,6 +144,8 @@ jobs:
           token: ${{ secrets.CI_PAT }}
           committer: PProfizi <paul.profizi@ansys.com>
           author: PProfizi <paul.profizi@ansys.com>
+          reviewers: ansys/dpf_integration_proxies
+          assignees: ansys/dpf_integration_proxies
 
       - name: "Kill all servers"
         uses: ansys/pydpf-actions/kill-dpf-servers@v2.3

--- a/.github/workflows/update_operators.yml
+++ b/.github/workflows/update_operators.yml
@@ -139,7 +139,7 @@ jobs:
           title: Update generated code for DPF ${{ github.event.inputs.ANSYS_VERSION || '242' }}${{ github.event.inputs.standalone_branch_suffix || '' }} on ${{ github.ref_name }}
           body: An update of generated code has been triggered either manually or by an update in the dpf-standalone repository.
           branch: maint/update_code_for_${{ github.event.inputs.ANSYS_VERSION || '242' }}${{ github.event.inputs.standalone_branch_suffix || '' }}_on_${{ github.ref_name }}
-          labels: maintenance
+          labels: server-sync
           token: ${{ steps.generate-token.outputs.token }}
           committer: PProfizi <paul.profizi@ansys.com>
           author: PProfizi <paul.profizi@ansys.com>

--- a/.github/workflows/update_operators.yml
+++ b/.github/workflows/update_operators.yml
@@ -16,6 +16,8 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
+      token:
 
 env:
   PACKAGE_NAME: ansys-dpf-core
@@ -132,6 +134,7 @@ jobs:
           body: An update of generated code has been triggered either manually or by an update in the dpf-standalone repository.
           branch: maint/update_code_for_${{ github.event.inputs.ANSYS_VERSION || '242' }}${{ github.event.inputs.standalone_branch_suffix || '' }}_on_${{ github.ref_name }}
           labels: maintenance
+          token: secrets.PYANSYS_CI_BOT_TOKEN
 
       - name: "Kill all servers"
         uses: ansys/pydpf-actions/kill-dpf-servers@v2.3

--- a/.github/workflows/update_operators.yml
+++ b/.github/workflows/update_operators.yml
@@ -135,6 +135,8 @@ jobs:
           branch: maint/update_code_for_${{ github.event.inputs.ANSYS_VERSION || '242' }}${{ github.event.inputs.standalone_branch_suffix || '' }}_on_${{ github.ref_name }}
           labels: maintenance
           token: secrets.CI_TOKEN
+          committer: PProfizi <paul.profizi@ansys.com>
+          author: PProfizi <paul.profizi@ansys.com>
 
       - name: "Kill all servers"
         uses: ansys/pydpf-actions/kill-dpf-servers@v2.3

--- a/.github/workflows/update_operators.yml
+++ b/.github/workflows/update_operators.yml
@@ -119,11 +119,11 @@ jobs:
         run: |
           git status
 
-      - uses: tibdex/github-app-token@v2
-        id: generate-token
-        with:
-          app_id: ${{ secrets.CI_APP_ID }}
-          private_key: ${{ secrets.CI_APP_TOKEN }}
+#      - uses: tibdex/github-app-token@v2
+#        id: generate-token
+#        with:
+#          app_id: ${{ secrets.CI_APP_ID }}
+#          private_key: ${{ secrets.CI_APP_TOKEN }}
 
       - name: "Create Pull Request"
         uses: peter-evans/create-pull-request@v4
@@ -140,7 +140,8 @@ jobs:
           body: An update of generated code has been triggered either manually or by an update in the dpf-standalone repository.
           branch: maint/update_code_for_${{ github.event.inputs.ANSYS_VERSION || '242' }}${{ github.event.inputs.standalone_branch_suffix || '' }}_on_${{ github.ref_name }}
           labels: server-sync
-          token: ${{ steps.generate-token.outputs.token }}
+#          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ secrets.CI_PAT }}
           committer: PProfizi <paul.profizi@ansys.com>
           author: PProfizi <paul.profizi@ansys.com>
 


### PR DESCRIPTION
This PR enacts changes on update_operators.yml to be called directly be the dpf_standalone PRs which will wait for the checks results.
This way the dpf-standalone PR actually properly tests updated client code based on the server modifications proposed in the dpf_standalone Windows PR.
Also, use of a PAT enables for automatic run of the checks upon PR creation, unlike the previous version. 