### PR TITLE
Remove unstable tests and examples

### DIFF
--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -195,14 +195,14 @@ jobs:
           command: |
             pytest $DEBUG $COVERAGE $RERUNS --junitxml=tests/junit/test-results9.xml test_service/.
 
-      - name: "Test API Entry"
-        shell: bash
-        working-directory: tests
-        run: |
-          cd entry
-          pytest $DEBUG $COVERAGE $RERUNS --junitxml=junit/test-results10.xml  .
-        if: always()
-        timeout-minutes: 10
+#      - name: "Test API Entry"
+#        shell: bash
+#        working-directory: tests
+#        run: |
+#          cd entry
+#          pytest $DEBUG $COVERAGE $RERUNS --junitxml=junit/test-results10.xml  .
+#        if: always()
+#        timeout-minutes: 10
 
       - name: "Upload Test Results"
         uses: actions/upload-artifact@v3

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -59,6 +59,7 @@ for example in glob(r"../../examples/**/*.py"):
         example_name = example.split(os.path.sep)[-1]
         print(f"Example {example_name} skipped as it requires DPF {minimum_version_str}.")
         ignored_pattern += f"|{example_name}"
+ignored_pattern += "|11-server_types.py"
 ignored_pattern += r")"
 
 # -- General configuration ---------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -274,6 +274,7 @@ def test_go_away_server():
     not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_4_0,
     reason="Not existing in version lower than 4.0",
 )
+@pytest.mark.skipif(running_docker, reason="Unstable on Docker")
 def test_start_after_shutting_down_server():
     remote_server = start_local_server(
         config=dpf.core.AvailableServerConfigs.GrpcServer, as_global=False


### PR DESCRIPTION
Commenting-out `entry` tests on Docker, and `11-server_types.py` example when generating the doc examples gallery.
Issues to be identified later. 

See: 
- `entry` on Docker: [crash](https://github.com/ansys/pydpf-core/actions/runs/7222676515/job/19688595265?pr=1331#step:25:26), [failure](https://github.com/ansys/pydpf-core/actions/runs/7540074150/job/20523909509?pr=1353#step:25:166), [timeout](https://github.com/ansys/pydpf-core/actions/runs/7539247154/job/20521382199?pr=1352#step:25:37)
- `server_types` example on doc build: [crash](https://github.com/ansys/pydpf-core/actions/runs/7540074150/job/20523909206?pr=1353#step:18:33)