### PR TITLE
MeshInfo.parts helper

### DIFF
--- a/src/ansys/dpf/core/generic_data_container.py
+++ b/src/ansys/dpf/core/generic_data_container.py
@@ -4,9 +4,13 @@
 GenericDataContainer
 ====================
 """
+from __future__ import annotations
 import traceback
 import warnings
 import builtins
+from typing import Union, List, TYPE_CHECKING
+if TYPE_CHECKING:  # pragma: no cover
+    from ansys.dpf.core import Field, Scoping, StringField, GenericDataContainer
 
 from ansys.dpf.core import server as server_module
 from ansys.dpf.core import errors
@@ -82,15 +86,19 @@ class GenericDataContainer:
 
         return _description(self._internal_obj, self._server)
 
-    def set_property(self, property_name, prop):
+    def set_property(
+            self,
+            property_name: str,
+            prop: Union[int, float, str, Field, StringField, GenericDataContainer, Scoping]
+    ):
         """Register given property with the given name.
 
         Parameters
         ----------
-        property_name : str
+        property_name:
             Property name.
-        prop : Int, String, Float, Field, StringField, GenericDataContainer, Scoping
-            object instance.
+        prop:
+            Property object.
         """
 
         any_dpf = Any.new_from(prop, self._server)

--- a/src/ansys/dpf/core/generic_data_container.py
+++ b/src/ansys/dpf/core/generic_data_container.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import traceback
 import warnings
 import builtins
-from typing import Union, List, TYPE_CHECKING
+from typing import Union, TYPE_CHECKING
 if TYPE_CHECKING:  # pragma: no cover
     from ansys.dpf.core import Field, Scoping, StringField, GenericDataContainer
 

--- a/src/ansys/dpf/core/mesh_info.py
+++ b/src/ansys/dpf/core/mesh_info.py
@@ -60,6 +60,7 @@ class MeshInfo:
             raise ValueError(
                 "Arguments generic_data_container and mesh_info are mutually exclusive."
             )
+        self._part_map = None
         self._zone_map = None
         self._cell_zone_map = None
         self._face_zone_map = None
@@ -224,6 +225,29 @@ class MeshInfo:
             return self.generic_data_container.get_property("part_names")
         else:
             return None
+
+    @property
+    def parts(self) -> dict:
+        """Dictionary of available part IDs to part names.
+
+        Returns
+        -------
+        parts:
+            Map of part IDs to part names.
+
+        .. warning:
+            Currently unavailable for LegacyGrpc servers.
+        """
+        if self._part_map:
+            return self._part_map
+        part_names = self.part_names
+        part_map = {}
+        if part_names:
+            names = part_names.data
+            for i, key in enumerate(part_names.scoping.ids):
+                part_map[str(key)] = names[i]
+        self._part_map = part_map
+        return self._part_map
 
     @property
     def part_scoping(self):

--- a/src/ansys/dpf/core/string_field.py
+++ b/src/ansys/dpf/core/string_field.py
@@ -16,6 +16,7 @@ from ansys.dpf.gate import (
     dpf_vector,
     integral_types,
 )
+from typing import List
 
 
 class StringField(_FieldBase):
@@ -198,7 +199,7 @@ class StringField(_FieldBase):
             data = self.get_entity_data(index)
             return data
 
-    def append(self, data, scopingid):
+    def append(self, data: List[str], scopingid: int):
         string_list = integral_types.MutableListString(data)
         self._api.csstring_field_push_back(self, scopingid, _get_size_of_list(data), string_list)
 

--- a/tests/test_mesh_info.py
+++ b/tests/test_mesh_info.py
@@ -491,6 +491,9 @@ def test_mesh_info_zones(fluent_multi_species, server_clayer):
     assert mesh_info.face_zones == ref_face_zones
 
 
+@pytest.mark.skipif(
+    not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_0, reason="Available for servers >=7.0"
+)
 def test_mesh_info_parts(server_type):
     parts = ["part_1", "part_2"]
     part_ids = list(range(1, len(parts)+1))

--- a/tests/test_mesh_info.py
+++ b/tests/test_mesh_info.py
@@ -489,3 +489,18 @@ def test_mesh_info_zones(fluent_multi_species, server_clayer):
         '7': 'velocity-inlet-7'
     }
     assert mesh_info.face_zones == ref_face_zones
+
+
+def test_mesh_info_parts(server_type):
+    parts = ["part_1", "part_2"]
+    part_ids = list(range(1, len(parts)+1))
+    part_names = dpf.StringField(nentities=len(part_ids))
+    for part_id in part_ids:
+        part_names.append(data=[parts[part_id-1]], scopingid=part_id)
+    part_scoping = dpf.Scoping(location="part", ids=part_ids)
+    gdc = dpf.GenericDataContainer()
+    gdc.set_property(property_name="part_names", prop=part_names)
+    gdc.set_property(property_name="part_scoping", prop=part_scoping)
+    mesh_info = dpf.MeshInfo(generic_data_container=gdc, server=server_type)
+    ref = """{'1': 'part_1', '2': 'part_2'}"""
+    assert str(mesh_info.parts) == ref


### PR DESCRIPTION
Adds `MeshInfo.parts` helper -> returns a dictionary of part ID to part name to prevent from having to manipulate PropertyFields. 