### PR TITLE
Fix test_entry.py::test_license_agr

### DIFF
--- a/tests/entry/test_entry.py
+++ b/tests/entry/test_entry.py
@@ -8,6 +8,7 @@ from ansys.dpf.core import examples
 from ansys.dpf.core.core import errors
 from conftest import running_docker
 
+import time
 
 @pytest.mark.order(1)
 @pytest.mark.skipif(
@@ -17,11 +18,14 @@ from conftest import running_docker
     reason="Tests ANSYS_DPF_ACCEPT_LA",
 )
 def test_license_agr(restore_accept_la_env):
+    dpf.server.shutdown_global_server()
     config = dpf.AvailableServerConfigs.InProcessServer
     init_val = os.environ["ANSYS_DPF_ACCEPT_LA"]
     del os.environ["ANSYS_DPF_ACCEPT_LA"]
     with pytest.raises(errors.DPFServerException):
-        dpf.Operator("stream_provider").run()
+        dpf.start_local_server(config=config, as_global=True)
+    with pytest.raises(errors.DPFServerException):
+        dpf.Operator("stream_provider")
     os.environ["ANSYS_DPF_ACCEPT_LA"] = init_val
     dpf.start_local_server(config=config, as_global=True)
     assert "static" in examples.find_static_rst()

--- a/tests/entry/test_entry.py
+++ b/tests/entry/test_entry.py
@@ -21,8 +21,6 @@ def test_license_agr(restore_accept_la_env):
     init_val = os.environ["ANSYS_DPF_ACCEPT_LA"]
     del os.environ["ANSYS_DPF_ACCEPT_LA"]
     with pytest.raises(errors.DPFServerException):
-        dpf.start_local_server(config=config, as_global=True)
-    with pytest.raises(errors.DPFServerException):
         dpf.Operator("stream_provider").run()
     os.environ["ANSYS_DPF_ACCEPT_LA"] = init_val
     dpf.start_local_server(config=config, as_global=True)

--- a/tests/entry/test_entry.py
+++ b/tests/entry/test_entry.py
@@ -8,7 +8,6 @@ from ansys.dpf.core import examples
 from ansys.dpf.core.core import errors
 from conftest import running_docker
 
-import time
 
 @pytest.mark.order(1)
 @pytest.mark.skipif(

--- a/tests/entry/test_entry.py
+++ b/tests/entry/test_entry.py
@@ -23,7 +23,7 @@ def test_license_agr(restore_accept_la_env):
     with pytest.raises(errors.DPFServerException):
         dpf.start_local_server(config=config, as_global=True)
     with pytest.raises(errors.DPFServerException):
-        dpf.Operator("stream_provider")
+        dpf.Operator("stream_provider").run()
     os.environ["ANSYS_DPF_ACCEPT_LA"] = init_val
     dpf.start_local_server(config=config, as_global=True)
     assert "static" in examples.find_static_rst()

--- a/tests/entry/test_entry.py
+++ b/tests/entry/test_entry.py
@@ -22,7 +22,7 @@ def test_license_agr(restore_accept_la_env):
     del os.environ["ANSYS_DPF_ACCEPT_LA"]
     with pytest.raises(errors.DPFServerException):
         dpf.start_local_server(config=config, as_global=True)
-    with pytest.raises(KeyError):
+    with pytest.raises(errors.DPFServerException):
         dpf.Operator("stream_provider")
     os.environ["ANSYS_DPF_ACCEPT_LA"] = init_val
     dpf.start_local_server(config=config, as_global=True)


### PR DESCRIPTION
Following license changes in DPF Server, this test was failing

Basically the behavior should not be modified apart from the Operator Construction also throwing a DPF LA Exception.

However the test seemed to run an InProcessServer before even actually running the line which starts a server.

Which caused all plugins to be already loaded, and DPF to be already loaded, and I believe biasing the expected environnement of the test.


This should be merged in synchronization with the Licensing modifications server side