### PR TITLE
fix: ensure that Meilisearch secret is used in workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,6 @@ on:
 env:
   PACKAGE_NAME: ansys-dpf-core
   MODULE: core
-  MEILISEARCH_PUBLIC_API_KEY: ${{ secrets.MEILISEARCH_PUBLIC_API_KEY }}
 
 jobs:
   doc-style:
@@ -144,6 +143,8 @@ jobs:
         run: |
           build_doc.bat > ..\doc\log.txt && type ..\doc\log.txt 2>&1
         timeout-minutes: 60
+        env:
+          MEILISEARCH_PUBLIC_API_KEY: ${{ secrets.MEILISEARCH_PUBLIC_API_KEY }}
 
       - name: "Check for success"
         shell: bash


### PR DESCRIPTION
Continuation of #1302, fixes #1327 by adding the variable at step level. Everything is properly configured in the `conf.py` file and I can see the Meilisearch indices for PyDPF working as expected.

The latest stable documentation does not contain any reference to Meilisearch in its HTML, meaning that the `MEILISEARCH_PUBLIC_API_KEY` was not available when the docs built. I suspect that the `cmd` is starting a new shell with a new env, loosing track of the environment declared in the `docs.yml`.