### PR TITLE
Fix GrpcServer deletion after initialization failure

### DIFF
--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -683,6 +683,7 @@ class GrpcServer(CServer):
         # Load DPFClientAPI
         from ansys.dpf.core.misc import is_pypim_configured
 
+        self.live = False
         super().__init__(ansys_path=ansys_path, load_operators=load_operators)
         # Load Ans.Dpf.GrpcClient
         self._grpc_client_path = load_api.load_grpc_client(ansys_path=ansys_path)
@@ -1017,11 +1018,11 @@ class LegacyGrpcServer(BaseServer):
         # Use ansys.grpc.dpf
         from ansys.dpf.core.misc import is_pypim_configured
 
+        self.live = False
         super().__init__()
 
         self._info_instance = None
         self._own_process = launch_server
-        self.live = False
         self._local_server = False
         self._stubs = {}
         self.channel = None


### PR DESCRIPTION
Set `self.live=False` before starting initialization of a grpc server.