### PR TITLE
Detect container IP for a any Docker config 

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,5 @@ filterwarnings =
     ignore::DeprecationWarning
 norecursedirs = *
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
+markers =
+    slow

--- a/src/ansys/dpf/core/server.py
+++ b/src/ansys/dpf/core/server.py
@@ -206,6 +206,7 @@ def start_local_server(
         port += 1
 
     if use_docker:
+        ip = docker_config.find_ip_for_docker_container()
         port = docker_config.find_port_available_for_docker_bind(port)
     else:
         docker_config.use_docker = False

--- a/src/ansys/dpf/core/server_factory.py
+++ b/src/ansys/dpf/core/server_factory.py
@@ -176,6 +176,21 @@ class DockerConfig:
             f"\t- extra_args: {self.extra_args}\n"
         )
 
+    def find_ip_for_docker_container(self) -> int:
+        """Finds the ip for the container of interest defined by DPF_DOCKER."""
+        id_cmd = f"$(docker ps -q -f ancestor={self.docker_name})"
+        ip_cmd = "docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "
+        run_cmd = ip_cmd + id_cmd
+        b_shell = False
+        if os.name == "posix":
+            b_shell = True
+        with subprocess.Popen(
+            run_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=b_shell
+        ) as process:
+            with io.TextIOWrapper(process.stdout, encoding="utf-8") as log_out:
+                for line in log_out:
+                    print(line)
+
     @staticmethod
     def find_port_available_for_docker_bind(port: int) -> int:
         """Checks for available internal ``docker_server_port`` by looking at the stdout of


### PR DESCRIPTION
While investigating the use of Dev Containers, running DPF on Docker from a client Docker image requires detecting the IP of the concurrent Docker image. This is due to using `Docker from Docker` instead of `Docker in Docker`.
The latter produced errors concerning the licensing server not being found.
This first now produces errors concerning DNS resolution. 