### PR TITLE
Add support for DPF 8.1

### DIFF
--- a/src/ansys/dpf/core/_version.py
+++ b/src/ansys/dpf/core/_version.py
@@ -22,6 +22,7 @@ class ServerToAnsysVersion:
         "7.0": "2024R1",
         "7.1": "2024R1",
         "8.0": "2024R2",
+        "8.1": "2024R2",
     }
 
     def __getitem__(self, item):


### PR DESCRIPTION
Required for `ansys-dpf-core 0.11.0` to handle dev versions of DPF 8.1.