### PR TITLE
Remove custom __str__ methods for ScopingsContainer and MeshesContainers

### DIFF
--- a/src/ansys/dpf/core/meshes_container.py
+++ b/src/ansys/dpf/core/meshes_container.py
@@ -178,9 +178,3 @@ class MeshesContainer(Collection):
             DPF mesh to add or update.
         """
         return super()._add_entry(label_space, mesh)
-
-    def __str__(self):
-        txt = "DPF Meshes Container with\n"
-        txt += "\t%d mesh(es)\n" % len(self)
-        txt += f"\tdefined on labels {self.labels} \n\n"
-        return txt

--- a/src/ansys/dpf/core/scopings_container.py
+++ b/src/ansys/dpf/core/scopings_container.py
@@ -100,9 +100,3 @@ class ScopingsContainer(Collection):
             DPF scoping to add.
         """
         return super()._add_entry(label_space, scoping)
-
-    def __str__(self):
-        txt = "DPF Scopings Container with\n"
-        txt += "\t%d scoping(s)\n" % len(self)
-        txt += f"\tdefined on labels {self.labels} \n\n"
-        return txt


### PR DESCRIPTION
The custom `__str__` methods for `ScopingsContainers` and `MeshesContainers` are not needed, as the default `Collection` method is much richer (it directly relies on sever calls). See difference:

Custom method (to be removed with this PR):
![image](https://github.com/ansys/pydpf-core/assets/107186344/d6041c6b-69e2-4508-b4cf-38a05dd74e34)

Default method:
![image](https://github.com/ansys/pydpf-core/assets/107186344/a311cff9-c713-436f-b1f2-bba7c80793af)
