### PR TITLE
Several fixes to the release pipeline following 0.11.0

### DIFF
--- a/.github/workflows/ansys_lab.yml
+++ b/.github/workflows/ansys_lab.yml
@@ -72,5 +72,5 @@ jobs:
           git config --global user.name "pyansys-ci-bot"
           git add .
           git status
-          git commit -a -m ${{ inputs.version }}
+          git commit -a -m ${{ inputs.version }} || exit 0
           git push https://${{ secrets.PYANSYS_CI_BOT_TOKEN }}@github.com/ansys/pydpf-core.git --follow-tags

--- a/.github/workflows/ansys_lab.yml
+++ b/.github/workflows/ansys_lab.yml
@@ -24,7 +24,7 @@ jobs:
     name: "Deploy examples for Ansys Lab"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.DESTINATION_BRANCH_NAME }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     name: "Style Check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Setup Python"
         uses: actions/setup-python@v4.6.0
@@ -81,7 +81,7 @@ jobs:
     name: "Build linux1 wheel"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Install requirements"
         run: pip install -r requirements/requirements_build.txt

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -44,7 +44,7 @@ jobs:
     name: "Style Check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Setup Python"
         uses: actions/setup-python@v4.6.0
@@ -61,7 +61,7 @@ jobs:
     name: "Build linux1 wheel"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Install requirements"
         run: pip install -r requirements/requirements_build.txt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,7 +59,7 @@ jobs:
     name: "Documentation"
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Set licensing if necessary"
         if: inputs.ANSYS_VERSION > 231

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -62,7 +62,7 @@ jobs:
         os: ["windows-latest", "ubuntu-latest"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Set licensing if necessary"
         if: inputs.ANSYS_VERSION > 231

--- a/.github/workflows/examples_docker.yml
+++ b/.github/workflows/examples_docker.yml
@@ -65,7 +65,7 @@ jobs:
         os: ["ubuntu-latest"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Setup Python"
         uses: actions/setup-python@v4.6.1

--- a/.github/workflows/pydpf-post.yml
+++ b/.github/workflows/pydpf-post.yml
@@ -153,6 +153,7 @@ jobs:
           PACKAGE_NAME: ansys-dpf-post
           working-directory: pydpf-post/src
         if: inputs.test_docstrings == 'true'
+        timeout-minutes: 10
 
       - name: "Test API"
         shell: bash
@@ -160,6 +161,7 @@ jobs:
         run: |
           pytest $DEBUG --reruns 2 .
         if: always()
+        timeout-minutes: 20
 
       - name: "Kill all servers"
         uses: ansys/pydpf-actions/kill-dpf-servers@v2.3

--- a/.github/workflows/pydpf-post.yml
+++ b/.github/workflows/pydpf-post.yml
@@ -59,7 +59,7 @@ jobs:
         python-version: ["3.9"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Set licensing if necessary"
         if: inputs.ANSYS_VERSION > 231

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           file: HTML-doc-ansys-dpf-core.zip
           token: ${{ secrets.GITHUB_TOKEN }}
-          version: tags/${{ github.event.inputs.release_tag || needs.get_latest_tag.outputs.version }}
+          version: ${{ github.event.inputs.release_tag && format('tags/{0}', github.event.inputs.release_tag) || format('tags/{0}', needs.get_latest_tag.outputs.version) }}
 
       - name: "List downloaded assets"
         shell: bash

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -121,7 +121,7 @@ jobs:
           echo "VERSION_MEILI=$VERSION_MEILI" >> $GITHUB_ENV
 
       - name: "Deploy the latest documentation index"
-        uses: ansys/actions/doc-deploy-index@v4
+        uses: ansys/actions/doc-deploy-index@v5
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}/version/${{ env.VERSION }}
           index-name: pydpf-core-v${{ env.VERSION_MEILI }}

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -47,7 +47,7 @@ jobs:
     needs: get_latest_tag
     steps:
       - name: "Download Release Assets"
-        uses: robinraju/release-downloader@v1.8
+        uses: robinraju/release-downloader@v1.9
         with:
           tag: ${{ github.event.inputs.release_tag || needs.get_latest_tag.outputs.version }}
           fileName: "*.whl"

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -89,7 +89,7 @@ jobs:
           path: HTML-doc-ansys-dpf-core.zip
 
       - name: "Deploy the stable documentation"
-        uses: ansys/actions/doc-deploy-stable@v4
+        uses: ansys/actions/doc-deploy-stable@v5
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -83,7 +83,7 @@ jobs:
           ls
 
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: HTML-doc-ansys-dpf-core.zip
           path: HTML-doc-ansys-dpf-core.zip

--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -44,7 +44,7 @@ jobs:
         os: ["ubuntu-latest"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Setup Python"
         uses: actions/setup-python@v4.6.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,7 +100,7 @@ jobs:
         os: ["windows-latest", "ubuntu-latest"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Set licensing if necessary"
         if: inputs.ANSYS_VERSION > 231

--- a/.github/workflows/update_operators.yml
+++ b/.github/workflows/update_operators.yml
@@ -36,7 +36,7 @@ jobs:
       - name: echo distinct ID ${{ github.event.inputs.distinct_id }}
         run: echo ${{ github.event.inputs.distinct_id }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4.6.0


### PR DESCRIPTION
Update several actions to remove deprecation warning for `Node.js 16`.
Update ansys_lab.yml to not fail if no diff is found.
Fix `version` argument for the `fetch-gh-release-asset` action.
Add timeouts to the PyDPF-Post tests (it sometimes hangs).

Successful run: https://github.com/ansys/pydpf-core/actions/runs/7989894623