### PR TITLE
Feat/any collection

### DIFF
--- a/src/ansys/dpf/core/__init__.py
+++ b/src/ansys/dpf/core/__init__.py
@@ -72,7 +72,7 @@ from ansys.dpf.core.generic_support import GenericSupport
 from ansys.dpf.core.meshed_region import MeshedRegion
 from ansys.dpf.core.elements import element_types
 from ansys.dpf.core.result_info import ResultInfo
-from ansys.dpf.core.collection import Collection
+from ansys.dpf.core.collection import CollectionBase
 from ansys.dpf.core.workflow import Workflow
 from ansys.dpf.core.cyclic_support import CyclicSupport
 from ansys.dpf.core.element_descriptor import ElementDescriptor

--- a/src/ansys/dpf/core/__init__.py
+++ b/src/ansys/dpf/core/__init__.py
@@ -72,7 +72,7 @@ from ansys.dpf.core.generic_support import GenericSupport
 from ansys.dpf.core.meshed_region import MeshedRegion
 from ansys.dpf.core.elements import element_types
 from ansys.dpf.core.result_info import ResultInfo
-from ansys.dpf.core.collection import CollectionBase
+from ansys.dpf.core.collection_base import CollectionBase
 from ansys.dpf.core.workflow import Workflow
 from ansys.dpf.core.cyclic_support import CyclicSupport
 from ansys.dpf.core.element_descriptor import ElementDescriptor
@@ -103,6 +103,14 @@ from ansys.dpf.core.generic_data_container import GenericDataContainer
 
 from ansys.dpf.core.dpf_operator import available_operator_names
 
+
+from ansys.dpf.core.collection import CollectionFactory as _CollectionFactory
+
+
+CustomTypeFieldsCollection = _CollectionFactory(CustomTypeField)
+GenericDataContainersCollection = _CollectionFactory(GenericDataContainer)
+StringFieldsCollection = _CollectionFactory(StringField)
+
 # for matplotlib
 # solves "QApplication: invalid style override passed, ignoring it."
 os.environ["QT_STYLE_OVERRIDE"] = ""
@@ -115,3 +123,4 @@ _server_instances = []
 
 settings.set_default_pyvista_config()
 settings._forward_to_gate()
+

--- a/src/ansys/dpf/core/__init__.py
+++ b/src/ansys/dpf/core/__init__.py
@@ -107,6 +107,7 @@ from ansys.dpf.core.dpf_operator import available_operator_names
 from ansys.dpf.core.collection import CollectionFactory as _CollectionFactory
 
 
+# register classes for collection types:
 CustomTypeFieldsCollection = _CollectionFactory(CustomTypeField)
 GenericDataContainersCollection = _CollectionFactory(GenericDataContainer)
 StringFieldsCollection = _CollectionFactory(StringField)

--- a/src/ansys/dpf/core/_custom_operators_helpers.py
+++ b/src/ansys/dpf/core/_custom_operators_helpers.py
@@ -45,7 +45,7 @@ _type_to_output_method = [
         external_operator_api.external_operator_put_out_string_field,
     ),
     (scoping.Scoping, external_operator_api.external_operator_put_out_scoping),
-    (collection.Collection, external_operator_api.external_operator_put_out_collection),
+    (collection.CollectionBase, external_operator_api.external_operator_put_out_collection),
     (
         data_sources.DataSources,
         external_operator_api.external_operator_put_out_data_sources,

--- a/src/ansys/dpf/core/collection.py
+++ b/src/ansys/dpf/core/collection.py
@@ -98,6 +98,7 @@ class Collection(CollectionBase[TYPE]):
 
 
 def CollectionFactory(subtype, BaseClass=Collection):
+    """Creates classes deriving from Collection at runtime for a given subtype."""
     def __init__(self, **kwargs):
         BaseClass.__init__(self, **kwargs)
 

--- a/src/ansys/dpf/core/collection.py
+++ b/src/ansys/dpf/core/collection.py
@@ -23,7 +23,7 @@ class Collection(CollectionBase[TYPE]):
         Server with the channel connected to the remote or local instance.
         The default is ``None``, in which case an attempt is made to use the
         global server.
-    type: type
+    entries_type: type
         Type of the entries in the collection.
 
     Notes
@@ -31,15 +31,15 @@ class Collection(CollectionBase[TYPE]):
     Class available with server's version starting at 8.1 (Ansys 2024 R2 pre1).
     """
 
-    def __init__(self, collection=None, server=None, type: type = None):
+    def __init__(self, collection=None, server=None, entries_type: type = None):
         # step 1: get server
         self._server = server_module.get_or_create_server(server)
         if not self._server.meet_version("8.1"):
             raise errors.DpfVersionNotSupported("8.1")
 
         super().__init__(collection=collection, server=server)
-        if type is not None:
-            self.type = type
+        if entries_type is not None:
+            self.entries_type = entries_type
         if self._internal_obj is None:
             if self._server.has_client():
                 self._internal_obj = self._api.collection_of_any_new_on_client(self._server.client)
@@ -47,7 +47,7 @@ class Collection(CollectionBase[TYPE]):
                 self._internal_obj = self._api.collection_of_any_new()
 
     def create_subtype(self, obj_by_copy):
-        return create_dpf_instance(Any, obj_by_copy, self._server).cast(self.type)
+        return create_dpf_instance(Any, obj_by_copy, self._server).cast(self.entries_type)
 
     def get_entries(self, label_space):
         """Retrieve the entries at a label space.
@@ -102,5 +102,5 @@ def CollectionFactory(subtype, BaseClass=Collection):
     def __init__(self, **kwargs):
         BaseClass.__init__(self, **kwargs)
 
-    new_class = type(str(subtype.__name__) + "sCollection", (BaseClass,), {"__init__": __init__, "type": subtype})
+    new_class = type(str(subtype.__name__) + "sCollection", (BaseClass,), {"__init__": __init__, "entries_type": subtype})
     return new_class

--- a/src/ansys/dpf/core/collection.py
+++ b/src/ansys/dpf/core/collection.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""
+Collection
+===============
+"""
+from __future__ import annotations
+from ansys.dpf.core.any import Any
+from ansys.dpf.core.collection_base import CollectionBase, TYPE
+from ansys.dpf.core.common import create_dpf_instance
+from ansys.dpf.core import server as server_module, errors
+
+
+class Collection(CollectionBase[TYPE]):
+    """Represents a collection of dpf objects organised by label spaces.
+
+    Parameters
+    ----------
+    collection : ansys.grpc.dpf.collection_pb2.Collection or
+                ansys.dpf.core.Collection, optional
+        Create a collection from a collection message or create a copy from an
+        existing collection. The default is ``None``.
+    server : ansys.dpf.core.server, optional
+        Server with the channel connected to the remote or local instance.
+        The default is ``None``, in which case an attempt is made to use the
+        global server.
+    type: type
+        Type of the entries in the collection.
+
+    Notes
+    -----
+    Class available with server's version starting at 8.1 (Ansys 2024 R2 pre1).
+    """
+
+    def __init__(self, collection=None, server=None, type: type = None):
+        # step 1: get server
+        self._server = server_module.get_or_create_server(server)
+        if not self._server.meet_version("8.1"):
+            raise errors.DpfVersionNotSupported("8.1")
+
+        super().__init__(collection=collection, server=server)
+        if type is not None:
+            self.type = type
+        if self._internal_obj is None:
+            if self._server.has_client():
+                self._internal_obj = self._api.collection_of_any_new_on_client(self._server.client)
+            else:
+                self._internal_obj = self._api.collection_of_any_new()
+
+    def create_subtype(self, obj_by_copy):
+        return create_dpf_instance(Any, obj_by_copy, self._server).cast(self.type)
+
+    def get_entries(self, label_space):
+        """Retrieve the entries at a label space.
+
+        Parameters
+        ----------
+        label_space : dict[str,int]
+            Entries corresponding to a filter (label space) in the input. For example:
+            ``{"elshape":1, "body":12}``
+
+        Returns
+        -------
+        entries : list[self.type]
+            Entries corresponding to the request.
+        """
+        return super()._get_entries(label_space)
+
+    def get_entry(self, label_space_or_index) -> TYPE:
+        """Retrieve the entry at a requested index or label space.
+
+        Raises an exception if the request returns more than one entry.
+
+        Parameters
+        ----------
+        label_space_or_index : dict[str,int] , int
+            Scoping of the requested entry, such as ``{"time": 1, "complex": 0}``
+            or the index of the mesh.
+
+        Returns
+        -------
+        entry : self.type
+            Entry corresponding to the request.
+        """
+        return super()._get_entry(label_space_or_index)
+
+    def add_entry(self, label_space, entry):
+        """Add or update the entry at a requested label space.
+
+        Parameters
+        ----------
+        label_space : dict[str,int]
+            Label space of the requested meshes. For example, {"elshape":1, "body":12}.
+
+        entry : self.type
+            DPF entry to add or update.
+        """
+        return super()._add_entry(label_space, Any.new_from(entry, server=self._server))
+
+
+def CollectionFactory(subtype, BaseClass=Collection):
+    def __init__(self, **kwargs):
+        BaseClass.__init__(self, **kwargs)
+
+    new_class = type(str(subtype.__name__) + "sCollection", (BaseClass,), {"__init__": __init__, "type": subtype})
+    return new_class

--- a/src/ansys/dpf/core/collection_base.py
+++ b/src/ansys/dpf/core/collection_base.py
@@ -30,7 +30,7 @@ TYPE = TypeVar('TYPE')
 
 
 class CollectionBase(Generic[TYPE]):
-    type: Optional[type[TYPE]] = Scoping
+    type: Optional[type[TYPE]]
     """Represents a collection of entries ordered by labels and IDs.
 
     Parameters

--- a/src/ansys/dpf/core/collection_base.py
+++ b/src/ansys/dpf/core/collection_base.py
@@ -1,5 +1,5 @@
 """
-Collection
+CollectionBase
 ===========
 Contains classes associated with the DPF collection.
 

--- a/src/ansys/dpf/core/collection_base.py
+++ b/src/ansys/dpf/core/collection_base.py
@@ -25,7 +25,7 @@ from ansys.dpf.gate import (
 )
 
 
-class Collection:
+class CollectionBase:
     """Represents a collection of entries ordered by labels and IDs.
 
     Parameters
@@ -48,7 +48,7 @@ class Collection:
         # step2: if object exists, take the instance, else create it
         self._internal_obj = None
         if collection is not None:
-            if isinstance(collection, Collection):
+            if isinstance(collection, CollectionBase):
                 self._server = collection._server
                 core_api = self._server.get_api_for_type(
                     capi=data_processing_capi.DataProcessingCAPI,
@@ -478,7 +478,7 @@ class Collection:
             yield self[i]
 
 
-class IntegralCollection(Collection):
+class IntegralCollection(CollectionBase):
     """Creates a collection of integral type with a list.
 
     The collection of integral is the equivalent of an array of
@@ -511,7 +511,7 @@ class IntegralCollection(Collection):
         pass
 
 
-class IntCollection(Collection):
+class IntCollection(CollectionBase):
     """Creates a collection of integers with a list.
 
     The collection of integral is the equivalent of an array of
@@ -564,7 +564,7 @@ class IntCollection(Collection):
             return self._api.collection_get_data_as_int(self, 0)
 
 
-class FloatCollection(Collection):
+class FloatCollection(CollectionBase):
     """Creates a collection of floats (double64) with a list.
 
     The collection of integral is the equivalent of an array of
@@ -620,7 +620,7 @@ class FloatCollection(Collection):
             return self._api.collection_get_data_as_double(self, 0)
 
 
-class StringCollection(Collection):
+class StringCollection(CollectionBase):
     """Creates a collection of strings with a list.
 
     The collection of integral is the equivalent of an array of

--- a/src/ansys/dpf/core/collection_base.py
+++ b/src/ansys/dpf/core/collection_base.py
@@ -4,6 +4,7 @@ Collection
 Contains classes associated with the DPF collection.
 
 """
+from __future__ import annotations
 import abc
 import warnings
 import traceback
@@ -23,9 +24,13 @@ from ansys.dpf.gate import (
     dpf_vector,
     dpf_array,
 )
+from typing import Optional, Generic, TypeVar
+
+TYPE = TypeVar('TYPE')
 
 
-class CollectionBase:
+class CollectionBase(Generic[TYPE]):
+    type: Optional[type[TYPE]] = Scoping
     """Represents a collection of entries ordered by labels and IDs.
 
     Parameters
@@ -186,7 +191,7 @@ class CollectionBase:
         else:
             self._api.collection_add_label(self, label)
 
-    def _get_labels(self):
+    def _get_labels(self) -> list:
         """Retrieve labels scoping the collection.
 
         Returns
@@ -202,7 +207,7 @@ class CollectionBase:
 
     labels = property(_get_labels, set_labels, "labels")
 
-    def has_label(self, label):
+    def has_label(self, label) -> bool:
         """Check if a collection has a specified label.
 
         Parameters
@@ -263,7 +268,7 @@ class CollectionBase:
                 self._api.collection_get_obj_by_index(self, label_space_or_index)
             )
 
-    def _get_entry(self, label_space_or_index):
+    def _get_entry(self, label_space_or_index) -> TYPE:
         """Retrieve the entry at a requested label space or index.
 
         Parameters
@@ -511,7 +516,8 @@ class IntegralCollection(CollectionBase):
         pass
 
 
-class IntCollection(CollectionBase):
+class IntCollection(CollectionBase[int]):
+    type = int
     """Creates a collection of integers with a list.
 
     The collection of integral is the equivalent of an array of
@@ -564,7 +570,8 @@ class IntCollection(CollectionBase):
             return self._api.collection_get_data_as_int(self, 0)
 
 
-class FloatCollection(CollectionBase):
+class FloatCollection(CollectionBase[float]):
+    type = float
     """Creates a collection of floats (double64) with a list.
 
     The collection of integral is the equivalent of an array of
@@ -620,7 +627,8 @@ class FloatCollection(CollectionBase):
             return self._api.collection_get_data_as_double(self, 0)
 
 
-class StringCollection(CollectionBase):
+class StringCollection(CollectionBase[str]):
+    type = str
     """Creates a collection of strings with a list.
 
     The collection of integral is the equivalent of an array of

--- a/src/ansys/dpf/core/collection_base.py
+++ b/src/ansys/dpf/core/collection_base.py
@@ -1,6 +1,6 @@
 """
 CollectionBase
-===========
+==============
 Contains classes associated with the DPF collection.
 
 """
@@ -30,13 +30,11 @@ TYPE = TypeVar('TYPE')
 
 
 class CollectionBase(Generic[TYPE]):
-    type: Optional[type[TYPE]]
+    type: Optional[type[TYPE]] # type of the entries in the collection.
     """Represents a collection of entries ordered by labels and IDs.
 
     Parameters
     ----------
-    dpf_type :
-
     collection : ansys.grpc.dpf.collection_pb2.Collection, optional
         Collection to create from the collection message. The default is ``None``.
     server : server.DPFServer, optional

--- a/src/ansys/dpf/core/collection_base.py
+++ b/src/ansys/dpf/core/collection_base.py
@@ -30,7 +30,7 @@ TYPE = TypeVar('TYPE')
 
 
 class CollectionBase(Generic[TYPE]):
-    type: Optional[type[TYPE]] # type of the entries in the collection.
+    entries_type: Optional[type[TYPE]]  # type of the entries in the collection.
     """Represents a collection of entries ordered by labels and IDs.
 
     Parameters
@@ -406,8 +406,6 @@ class CollectionBase(Generic[TYPE]):
             support_capi,
             support_grpcapi,
             object_handler,
-            data_processing_capi,
-            data_processing_grpcapi,
         )
 
         data_api = self._server.get_api_for_type(
@@ -515,7 +513,7 @@ class IntegralCollection(CollectionBase):
 
 
 class IntCollection(CollectionBase[int]):
-    type = int
+    entries_type = int
     """Creates a collection of integers with a list.
 
     The collection of integral is the equivalent of an array of
@@ -569,7 +567,7 @@ class IntCollection(CollectionBase[int]):
 
 
 class FloatCollection(CollectionBase[float]):
-    type = float
+    entries_type = float
     """Creates a collection of floats (double64) with a list.
 
     The collection of integral is the equivalent of an array of
@@ -626,7 +624,7 @@ class FloatCollection(CollectionBase[float]):
 
 
 class StringCollection(CollectionBase[str]):
-    type = str
+    entries_type = str
     """Creates a collection of strings with a list.
 
     The collection of integral is the equivalent of an array of

--- a/src/ansys/dpf/core/common.py
+++ b/src/ansys/dpf/core/common.py
@@ -133,7 +133,7 @@ def types_enum_to_types():
         types.double: float,
         types.bool: bool,
         types.bytes: bytes,
-        types.collection: collection.Collection,
+        types.collection: collection.CollectionBase,
         types.fields_container: fields_container.FieldsContainer,
         types.scopings_container: scopings_container.ScopingsContainer,
         types.meshes_container: meshes_container.MeshesContainer,

--- a/src/ansys/dpf/core/common.py
+++ b/src/ansys/dpf/core/common.py
@@ -345,6 +345,7 @@ def type_to_internal_object_keyword():
 
     class _smart_dict_types(dict):
         def __getitem__(self, item):
+        """If found returns the item of key == ìtem`, else returns item with key matching `issubclass(item, key)`."""
             if item in self:
                 return super().__getitem__(item)
             else:

--- a/src/ansys/dpf/core/common.py
+++ b/src/ansys/dpf/core/common.py
@@ -345,7 +345,8 @@ def type_to_internal_object_keyword():
 
     class _smart_dict_types(dict):
         def __getitem__(self, item):
-        """If found returns the item of key == ìtem`, else returns item with key matching `issubclass(item, key)`."""
+            """If found returns the item of key == ìtem`, else returns item with key matching `issubclass(item,
+            key)`."""
             if item in self:
                 return super().__getitem__(item)
             else:

--- a/src/ansys/dpf/core/core.py
+++ b/src/ansys/dpf/core/core.py
@@ -257,10 +257,8 @@ def _description(dpf_entity_message, server=None):
     -------
        description : str
     """
-    try:
-        return BaseService(server, load_operators=False)._description(dpf_entity_message)
-    except:
-        return ""
+    return BaseService(server, load_operators=False)._description(dpf_entity_message)
+
 
 
 def _deep_copy(dpf_entity, server=None):

--- a/src/ansys/dpf/core/core.py
+++ b/src/ansys/dpf/core/core.py
@@ -257,7 +257,10 @@ def _description(dpf_entity_message, server=None):
     -------
        description : str
     """
-    return BaseService(server, load_operators=False)._description(dpf_entity_message)
+    try:
+        return BaseService(server, load_operators=False)._description(dpf_entity_message)
+    except:
+        return ""
 
 
 

--- a/src/ansys/dpf/core/custom_operator.py
+++ b/src/ansys/dpf/core/custom_operator.py
@@ -254,7 +254,7 @@ class CustomOperatorBase:
             if isinstance(data, type_tuple[0]):
                 return type_tuple[1](self._operator_data, index, data)
         if isinstance(data, (list, numpy.ndarray)):
-            data = collection.Collection.integral_collection(data, dpf.SERVER)
+            data = collection.CollectionBase.integral_collection(data, dpf.SERVER)
             return external_operator_api.external_operator_put_out_collection_as_vector(
                 self._operator_data, index, data
             )

--- a/src/ansys/dpf/core/data_tree.py
+++ b/src/ansys/dpf/core/data_tree.py
@@ -11,7 +11,7 @@ import weakref
 
 from ansys.dpf.core.mapping_types import types
 from ansys.dpf.core import server as server_module
-from ansys.dpf.core import collection
+from ansys.dpf.core import collection_base
 from ansys.dpf.core import errors, common
 from ansys.dpf.gate import (
     dpf_data_tree_abstract_api,
@@ -165,7 +165,7 @@ class DataTree:
                 if len(value) > 0 and isinstance(value[0], float):
                     self._api.dpf_data_tree_set_vec_double_attribute(self, key, value, len(value))
                 elif len(value) > 0 and isinstance(value[0], str):
-                    coll_obj = collection.StringCollection(
+                    coll_obj = collection_base.StringCollection(
                         list=value, local=True, server=self._server
                     )
                     self._api.dpf_data_tree_set_string_collection_attribute(self, key, coll_obj)
@@ -476,7 +476,7 @@ class DataTree:
             self._api.dpf_data_tree_get_vec_int_attribute(self, name, out, out.internal_size)
             out = out.tolist()
         elif type_to_return == types.vec_string:
-            coll_obj = collection.StringCollection(
+            coll_obj = collection_base.StringCollection(
                 collection=self._api.dpf_data_tree_get_string_collection_attribute(self, name),
                 server=self._server,
             )
@@ -503,7 +503,7 @@ class DataTree:
         >>> data_tree.attribute_names
         ['id', 'name', 'qualities']
         """
-        coll_obj = collection.StringCollection(
+        coll_obj = collection_base.StringCollection(
             collection=self._api.dpf_data_tree_get_available_attributes_names_in_string_collection(
                 self
             ),
@@ -531,7 +531,7 @@ class DataTree:
         >>> data_tree.sub_tree_names
         ['first', 'second']
         """
-        coll_obj = collection.StringCollection(
+        coll_obj = collection_base.StringCollection(
             collection=self._api.dpf_data_tree_get_available_sub_tree_names_in_string_collection(
                 self
             ),

--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -239,7 +239,7 @@ class Operator:
             from ansys.dpf.core import collection
 
             if server_meet_version("3.0", self._server):
-                inpt = collection.Collection.integral_collection(inpt, self._server)
+                inpt = collection.CollectionBase.integral_collection(inpt, self._server)
                 self._api.operator_connect_collection_as_vector(self, pin, inpt)
             else:
                 if all(isinstance(x, int) for x in inpt):
@@ -474,7 +474,7 @@ class Operator:
                 self._api.operator_connect_custom_type_field,
             ),
             (scoping.Scoping, self._api.operator_connect_scoping),
-            (collection.Collection, self._api.operator_connect_collection),
+            (collection.CollectionBase, self._api.operator_connect_collection),
             (data_sources.DataSources, self._api.operator_connect_data_sources),
             (
                 model.Model,

--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -339,6 +339,8 @@ class Operator:
             streams_container,
             generic_data_container,
             mesh_info,
+            collection_base,
+            any,
         )
 
         out = [
@@ -419,17 +421,24 @@ class Operator:
             (
                 dpf_vector.DPFVectorInt,
                 self._api.operator_getoutput_int_collection,
-                lambda obj: collection.IntCollection(
+                lambda obj, type: collection_base.IntCollection(
                     server=self._server, collection=obj
                 ).get_integral_entries(),
             ),
             (
                 dpf_vector.DPFVectorDouble,
                 self._api.operator_getoutput_double_collection,
-                lambda obj: collection.FloatCollection(
+                lambda obj, type: collection_base.FloatCollection(
                     server=self._server, collection=obj
                 ).get_integral_entries(),
             ),
+            (
+                collection.Collection,
+                self._api.operator_getoutput_as_any,
+                lambda obj, type: any.Any(
+                    server=self._server, any_dpf=obj
+                ).cast(type),
+            )
         ]
         if hasattr(self._api, "operator_getoutput_generic_data_container"):
             out.append(
@@ -447,7 +456,7 @@ class Operator:
             cyclic_support,
             data_sources,
             field,
-            collection,
+            collection_base,
             meshed_region,
             property_field,
             string_field,
@@ -474,7 +483,7 @@ class Operator:
                 self._api.operator_connect_custom_type_field,
             ),
             (scoping.Scoping, self._api.operator_connect_scoping),
-            (collection.CollectionBase, self._api.operator_connect_collection),
+            (collection_base.CollectionBase, self._api.operator_connect_collection),
             (data_sources.DataSources, self._api.operator_connect_data_sources),
             (
                 model.Model,
@@ -527,7 +536,7 @@ class Operator:
             return self._api.operator_run(self)
         out = None
         for type_tuple in self._type_to_output_method:
-            if output_type is type_tuple[0]:
+            if issubclass(output_type, type_tuple[0]):
                 if len(type_tuple) >= 3:
                     internal_obj = type_tuple[1](self, pin)
                     if internal_obj is None:
@@ -537,7 +546,7 @@ class Operator:
                         parameters = {type_tuple[2]: internal_obj}
                         out = output_type(**parameters, server=self._server)
                     else:
-                        out = type_tuple[2](internal_obj)
+                        out = type_tuple[2](internal_obj, output_type)
                 if out is None:
                     internal_obj = type_tuple[1](self, pin)
                     if internal_obj is None:

--- a/src/ansys/dpf/core/field.py
+++ b/src/ansys/dpf/core/field.py
@@ -12,7 +12,6 @@ from ansys.dpf.core import dimensionality
 from ansys.dpf.core.common import locations, natures, types, _get_size_of_list
 from ansys.dpf.core.field_base import _FieldBase, _LocalFieldBase
 from ansys.dpf.core.field_definition import FieldDefinition
-from ansys.dpf.core.plotter import Plotter
 from ansys.dpf.gate import (
     field_abstract_api,
     field_capi,
@@ -480,6 +479,7 @@ class Field(_FieldBase):
             Additional keyword arguments for the plotter. For additional keyword
             arguments, see ``help(pyvista.plot)``.
         """
+        from ansys.dpf.core.plotter import Plotter
         pl = Plotter(self.meshed_region, **kwargs)
         return pl.plot_contour(
             self,

--- a/src/ansys/dpf/core/fields_container.py
+++ b/src/ansys/dpf/core/fields_container.py
@@ -12,7 +12,7 @@ from ansys.dpf.core import field
 
 
 class FieldsContainer(CollectionBase[field.Field]):
-    type = field.Field
+    entries_type = field.Field
     """Represents a fields container, which contains fields belonging to a common result.
 
     A fields container is a set of fields ordered by labels and IDs. Each field

--- a/src/ansys/dpf/core/fields_container.py
+++ b/src/ansys/dpf/core/fields_container.py
@@ -6,12 +6,13 @@ FieldsContainer
 Contains classes associated with the DPF FieldsContainer.
 """
 from ansys import dpf
-from ansys.dpf.core.collection import Collection
+from ansys.dpf.core.collection_base import CollectionBase
 from ansys.dpf.core import errors as dpf_errors
 from ansys.dpf.core import field
 
 
-class FieldsContainer(Collection):
+class FieldsContainer(CollectionBase[field.Field]):
+    type = field.Field
     """Represents a fields container, which contains fields belonging to a common result.
 
     A fields container is a set of fields ordered by labels and IDs. Each field
@@ -350,7 +351,7 @@ class FieldsContainer(Collection):
         """
         labels = self.labels
         if not self.has_label("time") and (
-            len(self.labels) == 0 or (len(self.labels) == 1 and self.has_label("complex"))
+                len(self.labels) == 0 or (len(self.labels) == 1 and self.has_label("complex"))
         ):
             self.add_label("time")
         if len(self.labels) == 1:
@@ -373,7 +374,7 @@ class FieldsContainer(Collection):
             Time ID for the requested time set. The default is ``1``.
         """
         if not self.has_label("time") and (
-            len(self.labels) == 0 or (len(self.labels) == 1 and self.has_label("complex"))
+                len(self.labels) == 0 or (len(self.labels) == 1 and self.has_label("complex"))
         ):
             self.add_label("time")
         if not self.has_label("complex") and len(self.labels) == 1 and self.has_label("time"):

--- a/src/ansys/dpf/core/generic_data_container.py
+++ b/src/ansys/dpf/core/generic_data_container.py
@@ -18,7 +18,7 @@ from ansys.dpf.core.dpf_operator import _write_output_type_to_type
 from ansys.dpf.core import server as server_module
 from ansys.dpf.core import errors, types
 from ansys.dpf.core.any import Any
-from ansys.dpf.core import collection
+from ansys.dpf.core import collection_base
 from ansys.dpf.core.mapping_types import map_types_to_python
 
 
@@ -150,13 +150,13 @@ class GenericDataContainer:
             Description of the GenericDataContainer's contents
         """
 
-        coll_obj = collection.StringCollection(
+        coll_obj = collection_base.StringCollection(
             collection=self._api.generic_data_container_get_property_names(self),
             server=self._server,
         )
         property_names = coll_obj.get_integral_entries()
 
-        coll_obj = collection.StringCollection(
+        coll_obj = collection_base.StringCollection(
             collection=self._api.generic_data_container_get_property_types(self),
             server=self._server,
         )

--- a/src/ansys/dpf/core/meshes_container.py
+++ b/src/ansys/dpf/core/meshes_container.py
@@ -5,12 +5,13 @@ MeshesContainer
 Contains classes associated with the DPF MeshesContainer.
 """
 from ansys.dpf.core import meshed_region
-from ansys.dpf.core.collection import Collection
+from ansys.dpf.core.collection_base import CollectionBase
 from ansys.dpf.core.plotter import DpfPlotter
 from ansys.dpf.core import errors as dpf_errors
 
 
-class MeshesContainer(Collection):
+class MeshesContainer(CollectionBase[meshed_region.MeshedRegion]):
+    type = meshed_region.MeshedRegion
     """Represents a meshes container, which contains meshes split on a given space.
 
     Parameters
@@ -167,7 +168,7 @@ class MeshesContainer(Collection):
         return super().__getitem__(key)
 
     def add_mesh(self, label_space, mesh):
-        """Add or update the scoping at a requested label space.
+        """Add or update the mesh at a requested label space.
 
         Parameters
         ----------

--- a/src/ansys/dpf/core/meshes_container.py
+++ b/src/ansys/dpf/core/meshes_container.py
@@ -11,7 +11,7 @@ from ansys.dpf.core import errors as dpf_errors
 
 
 class MeshesContainer(CollectionBase[meshed_region.MeshedRegion]):
-    type = meshed_region.MeshedRegion
+    entries_type = meshed_region.MeshedRegion
     """Represents a meshes container, which contains meshes split on a given space.
 
     Parameters

--- a/src/ansys/dpf/core/result_info.py
+++ b/src/ansys/dpf/core/result_info.py
@@ -19,7 +19,7 @@ from ansys.dpf.gate import (
     data_processing_capi,
 )
 
-from ansys.dpf.core import collection
+from ansys.dpf.core import collection_base
 from ansys.dpf.core import server as server_module
 from ansys.dpf.core import available_result, support
 from ansys.dpf.core.cyclic_support import CyclicSupport
@@ -518,7 +518,7 @@ class ResultInfo:
         -----
         Available with server's version starting at 5.0.
         """
-        coll_obj = collection.StringCollection(
+        coll_obj = collection_base.StringCollection(
             collection=self._api.result_info_get_available_qualifier_labels_as_string_coll(self),
             server=self._server,
         )

--- a/src/ansys/dpf/core/scopings_container.py
+++ b/src/ansys/dpf/core/scopings_container.py
@@ -11,7 +11,7 @@ from ansys.dpf.core.collection_base import CollectionBase
 
 
 class ScopingsContainer(CollectionBase[scoping.Scoping]):
-    type = scoping.Scoping
+    entries_type = scoping.Scoping
     """A class used to represent a ScopingsContainer which contains
     scopings split on a given space
 

--- a/src/ansys/dpf/core/scopings_container.py
+++ b/src/ansys/dpf/core/scopings_container.py
@@ -7,10 +7,11 @@ Contains classes associated to the DPF ScopingsContainer
 """
 
 from ansys.dpf.core import scoping
-from ansys.dpf.core.collection import Collection
+from ansys.dpf.core.collection_base import CollectionBase
 
 
-class ScopingsContainer(Collection):
+class ScopingsContainer(CollectionBase[scoping.Scoping]):
+    type = scoping.Scoping
     """A class used to represent a ScopingsContainer which contains
     scopings split on a given space
 

--- a/src/ansys/dpf/core/support.py
+++ b/src/ansys/dpf/core/support.py
@@ -10,7 +10,7 @@ from ansys.dpf.gate import support_capi, support_grpcapi
 from ansys.dpf.core.check_version import version_requires
 
 from ansys.dpf.core import server as server_module
-from ansys.dpf.core import collection
+from ansys.dpf.core import collection_base
 
 
 class Support:
@@ -127,7 +127,7 @@ class Support:
         -----
         Available with server's version starting at 5.0.
         """
-        coll_obj = collection.StringCollection(
+        coll_obj = collection_base.StringCollection(
             collection=self._support_api.support_get_property_names_as_string_coll_for_fields(self),
             server=self._server,
         )
@@ -145,7 +145,7 @@ class Support:
         -----
         Available with server's version starting at 5.0.
         """
-        coll_obj = collection.StringCollection(
+        coll_obj = collection_base.StringCollection(
             collection=self._support_api.support_get_property_names_as_string_coll_for_property_fields(  # noqa: E501
                 self
             ),
@@ -165,7 +165,7 @@ class Support:
         -----
         Available with server's version starting at 5.0.
         """
-        coll_obj = collection.StringCollection(
+        coll_obj = collection_base.StringCollection(
             collection=self._support_api.support_get_property_names_as_string_coll_for_string_fields(  # noqa: E501
                 self
             ),

--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -296,6 +296,7 @@ class Workflow:
             collection,
             generic_data_container,
             any,
+            collection_base,
         )
 
         out = [
@@ -367,14 +368,14 @@ class Workflow:
             (
                 dpf_vector.DPFVectorInt,
                 self._api.work_flow_getoutput_int_collection,
-                lambda obj, type: collection.IntCollection(
+                lambda obj, type: collection_base.IntCollection(
                     server=self._server, collection=obj
                 ).get_integral_entries(),
             ),
             (
                 dpf_vector.DPFVectorDouble,
                 self._api.work_flow_getoutput_double_collection,
-                lambda obj, type: collection.FloatCollection(
+                lambda obj, type: collection_base.FloatCollection(
                     server=self._server, collection=obj
                 ).get_integral_entries(),
             ),

--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -193,7 +193,7 @@ class Workflow:
             from ansys.dpf.core import collection
 
             if server_meet_version("3.0", self._server):
-                inpt = collection.Collection.integral_collection(inpt, self._server)
+                inpt = collection.CollectionBase.integral_collection(inpt, self._server)
                 self._api.work_flow_connect_collection_as_vector(self, pin_name, inpt)
             else:
                 if all(isinstance(x, int) for x in inpt):
@@ -249,7 +249,7 @@ class Workflow:
                 self._api.work_flow_connect_custom_type_field,
             ),
             (scoping.Scoping, self._api.work_flow_connect_scoping),
-            (collection.Collection, self._api.work_flow_connect_collection),
+            (collection.CollectionBase, self._api.work_flow_connect_collection),
             (data_sources.DataSources, self._api.work_flow_connect_data_sources),
             (
                 model.Model,
@@ -295,6 +295,7 @@ class Workflow:
             workflow,
             collection,
             generic_data_container,
+            any,
         )
 
         out = [
@@ -366,16 +367,23 @@ class Workflow:
             (
                 dpf_vector.DPFVectorInt,
                 self._api.work_flow_getoutput_int_collection,
-                lambda obj: collection.IntCollection(
+                lambda obj, type: collection.IntCollection(
                     server=self._server, collection=obj
                 ).get_integral_entries(),
             ),
             (
                 dpf_vector.DPFVectorDouble,
                 self._api.work_flow_getoutput_double_collection,
-                lambda obj: collection.FloatCollection(
+                lambda obj, type: collection.FloatCollection(
                     server=self._server, collection=obj
                 ).get_integral_entries(),
+            ),
+            (
+                collection.Collection,
+                self._api.work_flow_getoutput_as_any,
+                lambda obj, type: any.Any(
+                    server=self._server, any_dpf=obj
+                ).cast(type),
             ),
         ]
         if hasattr(self._api, "work_flow_connect_generic_data_container"):
@@ -407,13 +415,13 @@ class Workflow:
         output_type = dpf_operator._write_output_type_to_type(output_type)
         out = None
         for type_tuple in self._type_to_output_method:
-            if output_type is type_tuple[0]:
+            if issubclass(output_type, type_tuple[0]):
                 if len(type_tuple) >= 3:
                     if isinstance(type_tuple[2], str):
                         parameters = {type_tuple[2]: type_tuple[1](self, pin_name)}
                         out = output_type(**parameters, server=self._server)
                     else:
-                        out = type_tuple[2](type_tuple[1](self, pin_name))
+                        out = type_tuple[2](type_tuple[1](self, pin_name), output_type)
                 if out is None:
                     try:
                         out = output_type(type_tuple[1](self, pin_name), server=self._server)

--- a/src/ansys/dpf/gate/any_grpcapi.py
+++ b/src/ansys/dpf/gate/any_grpcapi.py
@@ -38,6 +38,8 @@ class AnyGRPCAPI(any_abstract_api.AnyAbstractAPI):
             string_field,
             scoping,
             data_tree,
+            custom_type_field,
+            collection,
         )
 
         return [(int, base_pb2.Type.INT),
@@ -47,9 +49,11 @@ class AnyGRPCAPI(any_abstract_api.AnyAbstractAPI):
                 (field.Field, base_pb2.Type.FIELD),
                 (property_field.PropertyField, base_pb2.Type.PROPERTY_FIELD),
                 (string_field.StringField, base_pb2.Type.STRING_FIELD),
+                (custom_type_field.CustomTypeField, base_pb2.Type.CUSTOM_TYPE_FIELD),
                 (generic_data_container.GenericDataContainer, base_pb2.Type.GENERIC_DATA_CONTAINER),
                 (scoping.Scoping, base_pb2.Type.SCOPING),
                 (data_tree.DataTree, base_pb2.Type.DATA_TREE),
+                (collection.Collection, base_pb2.Type.COLLECTION, base_pb2.Type.ANY),
                 ]
 
     @staticmethod
@@ -60,9 +64,13 @@ class AnyGRPCAPI(any_abstract_api.AnyAbstractAPI):
         request.any.CopyFrom(any._internal_obj)
 
         for type_tuple in AnyGRPCAPI._type_to_message_type():
-            if any._internal_type == type_tuple[0]:
+            if issubclass(any._internal_type, type_tuple[0]):
                 request.type = type_tuple[1]
+                if len(type_tuple) > 2:
+                    request.subtype = type_tuple[2]
                 return _get_stub(any._server.client).GetAs(request)
+
+        raise KeyError(any._internal_type)
 
     @staticmethod
     def any_get_as_int(any):
@@ -106,6 +114,10 @@ class AnyGRPCAPI(any_abstract_api.AnyAbstractAPI):
         return AnyGRPCAPI._get_as(any).field
 
     @staticmethod
+    def any_get_as_custom_type_field(any):
+        return AnyGRPCAPI._get_as(any).field
+
+    @staticmethod
     def any_get_as_generic_data_container(any):
         return AnyGRPCAPI._get_as(any).generic_data_container
 
@@ -116,6 +128,10 @@ class AnyGRPCAPI(any_abstract_api.AnyAbstractAPI):
     @staticmethod
     def any_get_as_data_tree(any):
         return AnyGRPCAPI._get_as(any).data_tree
+
+    @staticmethod
+    def any_get_as_any_collection(any):
+        return AnyGRPCAPI._get_as(any).collection
 
     @staticmethod
     def _new_from(any, client=None):
@@ -177,6 +193,10 @@ class AnyGRPCAPI(any_abstract_api.AnyAbstractAPI):
 
     @staticmethod
     def any_new_from_string_field(any):
+        return AnyGRPCAPI._new_from(any, any._server)
+
+    @staticmethod
+    def any_new_from_custom_type_field(any):
         return AnyGRPCAPI._new_from(any, any._server)
 
     @staticmethod

--- a/src/ansys/dpf/gate/collection_grpcapi.py
+++ b/src/ansys/dpf/gate/collection_grpcapi.py
@@ -69,6 +69,11 @@ class CollectionGRPCAPI(collection_abstract_api.CollectionAbstractAPI):
         return _get_stub(client).Create(request)
 
     @staticmethod
+    def collection_of_any_new_on_client(client):
+        from ansys.grpc.dpf import base_pb2
+        return CollectionGRPCAPI.collection_new_on_client(client, base_pb2.Type.Value("ANY"))
+
+    @staticmethod
     def collection_add_label(collection, label):
         from ansys.grpc.dpf import collection_pb2
         request = collection_pb2.UpdateLabelsRequest()
@@ -140,7 +145,7 @@ class CollectionGRPCAPI(collection_abstract_api.CollectionAbstractAPI):
 
     @staticmethod
     def _collection_get_entries(collection, label_space_or_index):
-        from ansys.grpc.dpf import collection_pb2, scoping_pb2, field_pb2, meshed_region_pb2, base_pb2
+        from ansys.grpc.dpf import collection_pb2, scoping_pb2, field_pb2, meshed_region_pb2, base_pb2, dpf_any_message_pb2
         request = collection_pb2.EntryRequest()
         request.collection.CopyFrom(collection._internal_obj)
 
@@ -163,6 +168,10 @@ class CollectionGRPCAPI(collection_abstract_api.CollectionAbstractAPI):
                     entry = object_handler.ObjHandler(data_processing_grpcapi.DataProcessingGRPCAPI, field_pb2.Field())
                 elif collection._internal_obj.type == base_pb2.Type.Value("MESHED_REGION"):
                     entry = object_handler.ObjHandler(data_processing_grpcapi.DataProcessingGRPCAPI, meshed_region_pb2.MeshedRegion())
+                elif collection._internal_obj.type == base_pb2.Type.Value("ANY"):
+                    entry = object_handler.ObjHandler(data_processing_grpcapi.DataProcessingGRPCAPI, dpf_any_message_pb2.DpfAny())
+                else:
+                    raise NotImplementedError(f"collection {base_pb2.Type.Name(collection._internal_obj.type)} type is not implemented")
                 obj.dpf_type.Unpack(entry._internal_obj)
                 entry._server = collection._server
                 list_out.append(_CollectionEntry(label_space, entry))

--- a/src/ansys/dpf/gate/operator_grpcapi.py
+++ b/src/ansys/dpf/gate/operator_grpcapi.py
@@ -266,10 +266,16 @@ class OperatorGRPCAPI(operator_abstract_api.OperatorAbstractAPI):
             return response.data_sources
         elif response.HasField("cyc_support"):
             return response.cyc_support
-        elif hasattr(response,"workflow") and response.HasField("workflow"):
+        elif hasattr(response, "workflow") and response.HasField("workflow"):
             return response.workflow
-        elif hasattr(response,"data_tree") and response.HasField("data_tree"):
+        elif hasattr(response, "data_tree") and response.HasField("data_tree"):
             return response.data_tree
+        elif hasattr(response, "any") and response.HasField("any"):
+            return response.any
+        elif hasattr(response, "generic_data_container") and response.HasField("generic_data_container"):
+            return response.generic_data_container
+        else:
+            raise KeyError(response)
 
     @staticmethod
     def operator_getoutput_fields_container(op, iOutput):
@@ -460,6 +466,13 @@ class OperatorGRPCAPI(operator_abstract_api.OperatorAbstractAPI):
     def operator_getoutput_generic_data_container(op, iOutput):
         request = OperatorGRPCAPI.get_output_init(op, iOutput)
         stype = "generic_data_container"
+        subtype = ""
+        return OperatorGRPCAPI.get_output_finish(op, request, stype, subtype)
+
+    @staticmethod
+    def operator_getoutput_as_any(op, iOutput):
+        request = OperatorGRPCAPI.get_output_init(op, iOutput)
+        stype = "any"
         subtype = ""
         return OperatorGRPCAPI.get_output_finish(op, request, stype, subtype)
 

--- a/src/ansys/dpf/gate/workflow_grpcapi.py
+++ b/src/ansys/dpf/gate/workflow_grpcapi.py
@@ -340,6 +340,12 @@ class WorkflowGRPCAPI(workflow_abstract_api.WorkflowAbstractAPI):
         return WorkflowGRPCAPI.get_output_finish(wf, request, stype)
 
     @staticmethod
+    def work_flow_getoutput_as_any(wf, pin_name):
+        request = WorkflowGRPCAPI.get_output_init(wf, pin_name)
+        stype = "any"
+        return WorkflowGRPCAPI.get_output_finish(wf, request, stype)
+
+    @staticmethod
     def work_flow_getoutput_string(wf, pin_name):
         request = WorkflowGRPCAPI.get_output_init(wf, pin_name)
         stype = "string"

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+
+import conftest
+
+import pytest
+import numpy as np
+from ansys.dpf.core import CustomTypeField, CustomTypeFieldsCollection, GenericDataContainersCollection, \
+    StringFieldsCollection, StringField, GenericDataContainer, operators, types, Workflow
+from ansys.dpf.core.collection import Collection
+import random
+from dataclasses import dataclass, field
+
+
+@conftest.raises_for_servers_version_under("8.1")
+def test_create_collection(server_type):
+    mc = Collection(server=server_type, type=CustomTypeField)
+    assert mc._internal_obj is not None
+
+
+@conftest.raises_for_servers_version_under("8.1")
+def test_empty_index():
+    mc = Collection(type=CustomTypeField)
+    with pytest.raises(IndexError):
+        mc[0]
+
+
+def create_dummy_custom_type_field(server_type, np_type=np.uint64, size=4):
+    pfield = CustomTypeField(np_type, server=server_type)
+    pfield.scoping.ids = random.sample(range(10, 30), size)
+    list_data = np.array(random.sample(range(10, 30), size), dtype=np_type)
+    pfield.data = list_data
+    return pfield
+
+
+def create_dummy_string_field(server_type, size=4):
+    pfield = StringField(server=server_type)
+    pfield.scoping.ids = random.sample(range(10, 30), size)
+    list_data = ["hello" for _ in range(size)]
+    pfield.data = list_data
+    return pfield
+
+
+def create_dummy_gdc(server_type, prop="hi"):
+    pfield = GenericDataContainer(server=server_type)
+    pfield.set_property("prop", prop)
+    return pfield
+
+
+@dataclass
+class CollectionTypeHelper:
+    type: type
+    instance_creator: object
+    kwargs: dict = field(default_factory=dict)
+
+    @property
+    def name(self):
+        return type.__name__
+
+
+collection_helper = CollectionTypeHelper(Collection, create_dummy_custom_type_field, {"type": CustomTypeField})
+cust_type_field_collection_helper = CollectionTypeHelper(CustomTypeFieldsCollection, create_dummy_custom_type_field)
+string_field_collection_helper = CollectionTypeHelper(StringFieldsCollection, create_dummy_string_field)
+gdc_collection_helper = CollectionTypeHelper(GenericDataContainersCollection, create_dummy_gdc)
+
+
+@pytest.mark.parametrize("subtype_creator",
+                         [collection_helper, cust_type_field_collection_helper, string_field_collection_helper],
+                         ids=[collection_helper.name, cust_type_field_collection_helper.name,
+                              string_field_collection_helper.name])
+@conftest.raises_for_servers_version_under("8.1")
+def test_fill_collection(server_type, subtype_creator):
+    coll = subtype_creator.type(server=server_type, **subtype_creator.kwargs)
+    coll.labels = ["body", "time"]
+    for i in range(1, 5):
+        coll.add_entry({"body": 1, "time": i}, subtype_creator.instance_creator(server_type=server_type, size=i))
+    for i in range(1, 5):
+        assert coll.get_entry({"body": 1, "time": i}).shape == i
+    assert len(coll.get_entries({"body": 1})) == 4
+    assert coll.get_entries({"body": 1})[0].shape == 1
+    for i in range(1, 5):
+        assert coll[i - 1].shape == i
+    for i in range(1, 5):
+        assert coll.get_label_space(i - 1) == {"body": 1, "time": i}
+    assert (lab in coll.labels for lab in ("body", "time"))
+    # assert "collection" in str(coll)
+
+
+@conftest.raises_for_servers_version_under("8.1")
+def test_fill_gdc_collection(server_type):
+    coll = GenericDataContainersCollection(server=server_type)
+    coll.labels = ["body", "time"]
+    for i in range(1, 5):
+        coll.add_entry({"body": 1, "time": i}, create_dummy_gdc(server_type=server_type, prop=i))
+    for i in range(1, 5):
+        assert coll.get_entry({"body": 1, "time": i}).get_property("prop") == i
+    assert len(coll.get_entries({"body": 1})) == 4
+    assert coll.get_entries({"body": 1})[0].get_property("prop") == 1
+    for i in range(1, 5):
+        assert coll[i - 1].get_property("prop") == i
+    for i in range(1, 5):
+        assert coll.get_label_space(i - 1) == {"body": 1, "time": i}
+    assert (lab in coll.labels for lab in ("body", "time"))
+    # assert "collection" in str(coll)
+
+
+@pytest.mark.parametrize("subtype_creator",
+                         [collection_helper, cust_type_field_collection_helper, string_field_collection_helper,
+                          gdc_collection_helper],
+                         ids=[collection_helper.name, cust_type_field_collection_helper.name,
+                              string_field_collection_helper.name, gdc_collection_helper.name])
+@conftest.raises_for_servers_version_under("8.1")
+def test_connect_collection_operator(server_type, subtype_creator):
+    coll = subtype_creator.type(server=server_type, **subtype_creator.kwargs)
+    coll.labels = ["body"]
+    coll.add_entry({"body": 1}, subtype_creator.instance_creator(server_type=server_type))
+    op = operators.utility.forward(server=server_type)
+    op.connect(0, coll)
+    out = op.get_output(0, subtype_creator.type)
+    assert out is not None
+    assert len(out) == 1
+    op.inputs.connect(coll)
+    out = op.get_output(0, subtype_creator.type)
+    assert out is not None
+    assert len(out) == 1
+
+
+@pytest.mark.parametrize("subtype_creator",
+                         [collection_helper, cust_type_field_collection_helper, string_field_collection_helper,
+                          gdc_collection_helper],
+                         ids=[collection_helper.name, cust_type_field_collection_helper.name,
+                              string_field_collection_helper.name, gdc_collection_helper.name])
+@conftest.raises_for_servers_version_under("8.1")
+def test_connect_collection_workflow(server_type, subtype_creator):
+    coll = subtype_creator.type(server=server_type, **subtype_creator.kwargs)
+    coll.labels = ["body"]
+    coll.add_entry({"body": 1}, subtype_creator.instance_creator(server_type=server_type))
+    wf = Workflow(server=server_type)
+    op = operators.utility.forward(server=server_type)
+    wf.set_input_name("in", 0, op)
+    wf.set_output_name("out", op, 0)
+    wf.connect("in", coll)
+    out = wf.get_output("out", subtype_creator.type)
+    assert out is not None
+    assert len(out) == 1
+    op.inputs.connect(coll)
+    out = op.get_output(0, subtype_creator.type)
+    assert out is not None
+    assert len(out) == 1

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -13,13 +13,13 @@ from dataclasses import dataclass, field
 
 @conftest.raises_for_servers_version_under("8.1")
 def test_create_collection(server_type):
-    mc = Collection(server=server_type, type=CustomTypeField)
+    mc = Collection(server=server_type, entries_type=CustomTypeField)
     assert mc._internal_obj is not None
 
 
 @conftest.raises_for_servers_version_under("8.1")
 def test_empty_index():
-    mc = Collection(type=CustomTypeField)
+    mc = Collection(entries_type=CustomTypeField)
     with pytest.raises(IndexError):
         mc[0]
 
@@ -57,7 +57,7 @@ class CollectionTypeHelper:
         return type.__name__
 
 
-collection_helper = CollectionTypeHelper(Collection, create_dummy_custom_type_field, {"type": CustomTypeField})
+collection_helper = CollectionTypeHelper(Collection, create_dummy_custom_type_field, {"entries_type": CustomTypeField})
 cust_type_field_collection_helper = CollectionTypeHelper(CustomTypeFieldsCollection, create_dummy_custom_type_field)
 string_field_collection_helper = CollectionTypeHelper(StringFieldsCollection, create_dummy_string_field)
 gdc_collection_helper = CollectionTypeHelper(GenericDataContainersCollection, create_dummy_gdc)


### PR DESCRIPTION
- rename existing `Collection` base class as `CollectionBase`
- Create API for collection: registering new type of collection can be done in `src/ansys/dpf/core/__init__.py` using `_CollectionFactory`.
  Internal implementation uses AnyCollection
- Add API to create/cast any from `AnyCollection` and `CustomTypeField`