### PR TITLE
Fix doc styling errors reported by Vale

### DIFF
--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -31,7 +31,7 @@ To use PyDPF-Core, you need access to a DPF Server.
   and requires accepting the :ref:`DPF Preview License Agreement<target_to_license_terms>`.
   Once you have access to an Ansys license, follow the guidelines to :ref:`install a standalone DPF Server <target_installing_server>`.
 
-For more information regarding installing, managing and running DPF servers, see :ref:`ref_dpf_server`.
+For more information regarding installing, managing, and running DPF servers, see :ref:`ref_dpf_server`.
 
 Install PyDPF-Core
 ------------------

--- a/doc/source/getting_started/licensing.rst
+++ b/doc/source/getting_started/licensing.rst
@@ -116,7 +116,7 @@ operators) which do not perform any data transformation.
 
 For example, when considering result operators, they perform data transformation if the requested
 location is not the native result location. In that case, averaging occurs which is considered
-as data transformation (for example, elemental to nodal, nodal to elemental...).
+as data transformation (such as elemental to nodal, nodal to elemental, or any other location change).
 
 .. _licensing_server_context:
 Server context


### PR DESCRIPTION
Recent PR files comparisons kept warning of Vale errors (such as [here](https://github.com/ansys/pydpf-core/pull/1465/files)).