### PR TITLE
docs: update the style of the operator reference in docs

### DIFF
--- a/doc/source/operator_reference_load.rst
+++ b/doc/source/operator_reference_load.rst
@@ -13,8 +13,8 @@ Loading operators.
       src="_static/dpf_operators.html#CPython"
       style="
         position: fixed;
-        top: 50px;
-        bottom: 0px;
+        top: 55px;
+        bottom: 10px;
         right: 0px;
         width: 100%;
         border: none;

--- a/doc/source/operator_reference_load_apis.rst
+++ b/doc/source/operator_reference_load_apis.rst
@@ -12,8 +12,8 @@ Loading operators.
       src="_static/dpf_operators.html"
       style="
         position: fixed;
-        top: 50px;
-        bottom: 0px;
+        top: 55px;
+        bottom: 10px;
         right: 0px;
         width: 100%;
         border: none;

--- a/doc/source/operator_reference_load_apis.rst
+++ b/doc/source/operator_reference_load_apis.rst
@@ -12,7 +12,7 @@ Loading operators.
       src="_static/dpf_operators.html"
       style="
         position: fixed;
-        top: 36px;
+        top: 50px;
         bottom: 0px;
         right: 0px;
         width: 100%;
@@ -21,6 +21,6 @@ Loading operators.
         padding: 0;
         overflow: hidden;
         z-index: 1000;
-        height: 100%;
+        height: 94%;
       ">
     </iframe>


### PR DESCRIPTION
fix the issue with header and example in the operator.rst file in https://dpf.docs.pyansys.com/version/stable/operator_reference_load_apis.html ![image](https://github.com/ansys/pydpf-core/assets/104772255/f7d50582-5c0c-4b6d-a2f5-ad61a5bd9d74)
