### PR TITLE
Add DataSources.add_domain_file_path

### DIFF
--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -211,6 +211,36 @@ class DataSources:
             else:
                 self._api.data_sources_add_file_path_with_key_utf8(self, str(filepath), key)
 
+    def add_domain_file_path(self, filepath, key, domain_id):
+        """Add a file path to the data sources.
+
+        Files not added as result files are accessory files, which contain accessory
+        information not present in the result files.
+
+        Parameters
+        ----------
+        filepath:
+            Path of the file.
+        key:
+            Extension of the file, which is used as a key for choosing the correct
+            plugin when a result is requested by an operator.
+        domain_id:
+            Domain ID for the distributed files.
+        Examples
+        --------
+        >>> from ansys.dpf import core as dpf
+        >>> data_sources = dpf.DataSources()
+        >>> data_sources.add_domain_file_path('/tmp/ds.dat', "dat", 1)
+
+        """
+        # The filename needs to be a fully qualified file name
+        if not os.path.dirname(filepath):
+            # append local path
+            filepath = os.path.join(os.getcwd(), os.path.basename(filepath))
+        self._api.data_sources_add_domain_file_path_with_key_utf8(
+            self, str(filepath), key, domain_id
+        )
+
     def add_file_path_for_specified_result(self, filepath, key="", result_key=""):
         """Add a file path for a specified result file key to the data sources.
 


### PR DESCRIPTION
This is to enable IronPython DPF code to work more easily when transcribed to PyDPF.