### PR TITLE
Exception to plot MeshesContainers containing empty meshes

### DIFF
--- a/src/ansys/dpf/core/meshes_container.py
+++ b/src/ansys/dpf/core/meshes_container.py
@@ -105,6 +105,8 @@ class MeshesContainer(CollectionBase[meshed_region.MeshedRegion]):
 
             random_color = "color" not in kwargs
             for mesh in self:
+                if mesh.nodes.n_nodes == 0:
+                    continue
                 if random_color:
                     kwargs["color"] = [random(), random(), random()]
                 pl.add_mesh(


### PR DESCRIPTION
En exception is introduced in the code that plot `MeshesContainers` to be able to plot it if any of the `MeshedRegion`s in the container is empty. While working lately with IsoContours in distributed, it may be the case that an isocontour does not pass through a given partition of the spatial domain. If that is the case, the isocontour mesh for that partition is an empty mesh (as it should, with 0 nodes and 0 elements). If all the isocontours are stored in a MeshesContainer, you end up with several meshes being empty and some not. As a user, I'd like to do `meshes_container.plot()` and still have a plot. This PR enables that.

Tesed interactively with a `MeshesContainer` comprised of entirely empty meshes and a white pyvista plotter pops-up (as it should).