### PR TITLE
Add 8.2 to prepare for post-release

### DIFF
--- a/src/ansys/dpf/core/_version.py
+++ b/src/ansys/dpf/core/_version.py
@@ -23,6 +23,7 @@ class ServerToAnsysVersion:
         "7.1": "2024R1",
         "8.0": "2024R2",
         "8.1": "2024R2",
+        "8.2": "2024R2",
     }
 
     def __getitem__(self, item):


### PR DESCRIPTION
Add `"8.2"` version to be able to merge the bump to 2024.2.pre1 in the server