### PR TITLE
Fix issue in model without faces

### DIFF
--- a/src/ansys/dpf/core/faces.py
+++ b/src/ansys/dpf/core/faces.py
@@ -296,8 +296,12 @@ class Faces:
         """
         if faceindex is None:
             faceindex = self._mesh.property_field(face_properties.faces_type).scoping.index(faceid)
+            if (faceindex < 0):
+                raise ValueError('face not found')
         elif faceid is None:
             faceid = self._mesh.property_field(face_properties.faces_type).scoping.id(faceindex)
+            if (faceid < 0):
+                raise ValueError('face not found')
         nodeIdx = self._mesh.property_field(
             face_properties.faces_nodes_connectivity
         ).get_entity_data(faceindex)

--- a/tests/test_faces.py
+++ b/tests/test_faces.py
@@ -88,7 +88,9 @@ def test_mesh_without_faces(mesh_wo_faces):
     assert mesh_wo_faces.faces.scoping.size == 0
     assert mesh_wo_faces.faces.faces_type_field.size == 0
     assert mesh_wo_faces.faces.faces_nodes_connectivity_field.size == 0
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as e:
         mesh_wo_faces.faces.face_by_id(1)
-    with pytest.raises(ValueError):
+        assert 'face not found' in e
+    with pytest.raises(ValueError) as e:
         mesh_wo_faces.faces.face_by_index(1)
+        assert 'face not found' in e

--- a/tests/test_faces.py
+++ b/tests/test_faces.py
@@ -11,6 +11,11 @@ def model_faces(fluent_axial_comp):
     faces = model.metadata.meshed_region.faces
     return faces
 
+@pytest.fixture()
+def mesh_wo_faces(simple_bar):
+    model = dpf.Model(simple_bar)
+    return model.metadata.meshed_region
+
 
 @pytest.mark.skipif(
     not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_0,
@@ -73,3 +78,17 @@ def test_face_scoping():
     assert faces_sco.location == dpf.locations.faces
     assert faces_sco.size == 3
     assert faces_sco.ids[2] == 4
+
+@pytest.mark.skipif(
+    not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_0,
+    reason="faces location was not supported before 7.0",
+)
+def test_mesh_without_faces(mesh_wo_faces):
+    assert mesh_wo_faces.faces.n_faces == 0
+    assert mesh_wo_faces.faces.scoping.size == 0
+    assert mesh_wo_faces.faces.faces_type_field.size == 0
+    assert mesh_wo_faces.faces.faces_nodes_connectivity_field.size == 0
+    with pytest.raises(ValueError):
+        mesh_wo_faces.faces.face_by_id(1)
+    with pytest.raises(ValueError):
+        mesh_wo_faces.faces.face_by_index(1)


### PR DESCRIPTION
A bug was reported server side pointing to a crash if faces are requested in a mesh that doesn't have them:
```
from ansys.dpf import core as dpf
from ansys.dpf.core import examples
filename = examples.download_pontoon()
model = dpf.Model(filename)
mesh = model.metadata.meshed_region
mesh.faces.face_by_id(1) # server crashes since there are no faces
```
We now handle the situation here. A test is added to ensure that the raise is expected.