### PR TITLE
Fix server shutdown

### DIFF
--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -382,6 +382,7 @@ class BaseServer(abc.ABC):
         self._session_instance = None
         self._base_service_instance = None
         self._context = None
+        self._info_instance = None
         self._docker_config = server_factory.RunningDockerConfig()
 
     def set_as_global(self, as_global=True):
@@ -431,9 +432,10 @@ class BaseServer(abc.ABC):
             ``"server_port"``, ``"server_process_id"``, ``"server_version"`` , ``"os"``
             and ``"path"`` keys.
         """
-        server_info = self._base_service.server_info
-        server_info["path"] = self.ansys_path
-        return server_info
+        if not self._info_instance:
+            self._info_instance = self._base_service.server_info
+            self._info_instance["path"] = self.ansys_path
+        return self._info_instance
 
     def _del_session(self):
         if self._session_instance:
@@ -782,6 +784,7 @@ class GrpcServer(CServer):
 
     def shutdown(self):
         if self.live:
+            info = self.info # initializing the info variable (giving access to ip and port): this can be required if start_local_server is called afterwards
             if self._remote_instance:
                 self._remote_instance.delete()
             try:
@@ -827,10 +830,7 @@ class GrpcServer(CServer):
         -------
         ip : str
         """
-        try:
-            return self.info["server_ip"]
-        except:
-            return ""
+        return self.info["server_ip"]
 
     @property
     def port(self):
@@ -840,10 +840,7 @@ class GrpcServer(CServer):
         -------
         port : int
         """
-        try:
-            return self.info["server_port"]
-        except:
-            return 0
+        return self.info["server_port"]
 
     @property
     def external_ip(self):
@@ -1034,8 +1031,6 @@ class LegacyGrpcServer(BaseServer):
 
         self.live = False
         super().__init__()
-
-        self._info_instance = None
         self._own_process = launch_server
         self._local_server = False
         self._stubs = {}
@@ -1134,10 +1129,7 @@ class LegacyGrpcServer(BaseServer):
         -------
         ip : str
         """
-        try:
-            return self.info["server_ip"]
-        except:
-            return ""
+        return self.info["server_ip"]
 
     @property
     def port(self):
@@ -1147,10 +1139,7 @@ class LegacyGrpcServer(BaseServer):
         -------
         port : int
         """
-        try:
-            return self.info["server_port"]
-        except:
-            return 0
+        return self.info["server_port"]
 
     @property
     def external_ip(self):
@@ -1221,14 +1210,15 @@ class LegacyGrpcServer(BaseServer):
 
     def shutdown(self):
         if self._own_process and self.live:
+            info = self.info # initializing the info variable (giving access to ip and port): this can be required if start_local_server is called afterwards
+            if self._remote_instance:
+                self._remote_instance.delete()
             try:
                 if hasattr(self, "_preparing_shutdown_func"):
                     self._preparing_shutdown_func[0](self._preparing_shutdown_func[1])
             except Exception as e:
                 warnings.warn("couldn't prepare shutdown: " + str(e.args))
 
-            if self._remote_instance:
-                self._remote_instance.delete()
             else:
                 try:
                     if hasattr(self, "_shutdown_func"):

--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -1210,7 +1210,7 @@ class LegacyGrpcServer(BaseServer):
 
     def shutdown(self):
         if self._own_process and self.live:
-            info = self.info # initializing the info variable (giving access to ip and port): this can be required if start_local_server is called afterwards
+            _ = self.info # initializing the info variable (giving access to ip and port): this can be required if start_local_server is called afterwards
             if self._remote_instance:
                 self._remote_instance.delete()
             try:

--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -784,7 +784,7 @@ class GrpcServer(CServer):
 
     def shutdown(self):
         if self.live:
-            info = self.info # initializing the info variable (giving access to ip and port): this can be required if start_local_server is called afterwards
+            _ = self.info # initializing the info variable (giving access to ip and port): this can be required if start_local_server is called afterwards
             if self._remote_instance:
                 self._remote_instance.delete()
             try:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -103,6 +103,15 @@ class TestServerConfigs:
         shutdown_all_session_servers()
         assert not has_local_server()
 
+    def test_start_shutdown_start(self, server_config):
+        set_server_configuration(server_config)
+        # print(dpf.core.SERVER_CONFIGURATION)
+        server = start_local_server(timeout=20)
+        server.shutdown()
+        server = start_local_server(timeout=20)
+        assert has_local_server()
+        shutdown_all_session_servers()
+
 
 @pytest.mark.parametrize("server_config", server_configs)
 class TestServer:


### PR DESCRIPTION
BUG: calling shutdown on a server prevents from starting another server on linux.
-> when a server is started, to choose the port to start the server on, all server instances are requested their ports but shutdown prevents the server to return its port. FIX is to store the port of the server before shutdown 