### PR TITLE
remove duplicated LA message

### DIFF
--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -126,7 +126,7 @@ def _wait_and_check_server_connection(
         def read_stderr():
             with io.TextIOWrapper(process.stderr, encoding="utf-8") as log_err:
                 for line in log_err:
-                    LOG.error(line)
+                    LOG.debug(line)
                     current_errors.append(line)
 
         stderr = read_stderr
@@ -140,7 +140,6 @@ def _wait_and_check_server_connection(
                     lines.append(line)
 
         stdout = read_stdout
-
     # must be in the background since the process reader is blocking
     Thread(target=stdout, daemon=True).start()
     Thread(target=stderr, daemon=True).start()


### PR DESCRIPTION
when ANSYS_DPF_ACCEPT_LA  is not accepted, the error message appears 4times: 
```
Dpf initialization encountered an error: DPF error - licensing failure: dpf core function call; DPF Preview License Agreement terms must be accepted using the ANSYS_DPF_ACCEPT_LA environment variable set to Y. Fore more information about DPF Preview License Agreement terms, see https://dpf.docs.pyansys.com/version/stable/user_guide/getting_started_with_dpf_server.html#dpf-preview-license-agreement.

terminate called after throwing an instance of 'ansys::dpf::DpfException'

  what():  DPF error - runtime error: dpf core function call; DPF Preview License Agreement terms must be accepted using the ANSYS_DPF_ACCEPT_LA environment variable set to Y. Fore more information about DPF Preview License Agreement terms, see https://dpf.docs.pyansys.com/version/stable/user_guide/getting_started_with_dpf_server.html#dpf-preview-license-agreement.

Dpf initialization encountered an error: DPF error - licensing failure: dpf core function call; DPF Preview License Agreement terms must be accepted using the ANSYS_DPF_ACCEPT_LA environment variable set to Y. Fore more information about DPF Preview License Agreement terms, see https://dpf.docs.pyansys.com/version/stable/user_guide/getting_started_with_dpf_server.html#dpf-preview-license-agreement.

terminate called after throwing an instance of 'ansys::dpf::DpfException'

  what():  DPF error - runtime error: dpf core function call; DPF Preview License Agreement terms must be accepted using the ANSYS_DPF_ACCEPT_LA environment variable set to Y. Fore more information about DPF Preview License Agreement terms, see https://dpf.docs.pyansys.com/version/stable/user_guide/getting_started_with_dpf_server.html#dpf-preview-license-agreement.

```

One duplicate is due to wrong usage of LOG error, see [doc ](https://docs.python.org/3/howto/logging.html) for good practices.
One duplicate is dur to wrong error handling server side (fixed in server PR)