### PR TITLE
Fix Operator.eval() in case output pin 0 is not named "fields_container"

### DIFF
--- a/src/ansys/dpf/core/outputs.py
+++ b/src/ansys/dpf/core/outputs.py
@@ -112,6 +112,9 @@ class _Outputs:
                         corresponding_pins.append(pin)
         return corresponding_pins
 
+    def __getitem__(self, index):
+        return self._outputs[index]
+
     def __str__(self):
         docstr = "Available outputs:\n"
         for output in self._outputs:

--- a/src/ansys/dpf/core/results.py
+++ b/src/ansys/dpf/core/results.py
@@ -263,7 +263,12 @@ class Result:
         >>> fc = disp.on_all_time_freqs.eval()
 
         """
-        fc = self.__call__().outputs.fields_container()
+        outputs = self.__call__().outputs
+        if hasattr(outputs, "fields_container"):
+            fc = outputs.fields_container()
+        else:
+            # Support operators where the first output is not named "field_container"
+            fc = outputs[0]()
         if self._specific_fc_type == "shape":
             fc = ElShapeFieldsContainer(fields_container=fc._get_ownership(), server=fc._server)
         elif self._specific_fc_type == "body":


### PR DESCRIPTION
I have stumbled upon operators where the output pin 0, despite being of type `fields_container`, is not named `fields_container`. 
That is an implicit rule we generally follow, not a hard one we can expect everyone to follow.
The `eval()` method should thus be made more generic.
It still tests for a `fields_container` type output pin, but it does not put any requirement on the naming.