### PR TITLE
DataSources.set_result_file_path recognizes .cas/dat.cff and .cas/dat.h5 files automatically

### DIFF
--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -120,6 +120,9 @@ class DataSources:
         # Handle no key given and no file extension
         if key == "" and os.path.splitext(filepath)[1] == "":
             key = self.guess_result_key(str(filepath))
+        # Look for another extension for .h5 and .cff files
+        if key == "" and os.path.splitext(filepath)[1] in [".h5", ".cff"]:
+            key = self.guess_second_key(str(filepath))
         if key == "":
             self._api.data_sources_set_result_file_path_utf8(self, str(filepath))
         else:
@@ -135,6 +138,16 @@ class DataSources:
             if result_key in base_name:
                 return result_key
         return ""
+
+    @staticmethod
+    def guess_second_key(filepath: str) -> str:
+        """For files with an h5 or cff extension, look for another extension."""
+        without_ext = os.path.splitext(filepath)[0]
+        new_split = os.path.splitext(without_ext)
+        new_key = ""
+        if len(new_split) > 1:
+            new_key = new_split[1][1:]
+        return new_key
 
     def set_domain_result_file_path(
             self, path: Union[str, os.PathLike], domain_id: int, key: Union[str, None] = None

--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -142,11 +142,14 @@ class DataSources:
     @staticmethod
     def guess_second_key(filepath: str) -> str:
         """For files with an h5 or cff extension, look for another extension."""
+        accepted = ["cas", "dat"]
         without_ext = os.path.splitext(filepath)[0]
         new_split = os.path.splitext(without_ext)
         new_key = ""
         if len(new_split) > 1:
-            new_key = new_split[1][1:]
+            key = new_split[1][1:]
+            if key in accepted:
+                new_key = key
         return new_key
 
     def set_domain_result_file_path(

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -57,6 +57,28 @@ def test_setresultpath_data_sources_no_extension(d3plot_beam, binout_glstat, ser
     assert data_sources.result_key == "binout"
 
 
+def test_set_resultpath_data_sources_h5(server_type):
+    from ansys.dpf.core import examples
+    cas_h5_file = examples.download_fluent_axial_comp(server=server_type)["cas"][0]
+    print(cas_h5_file)
+    data_sources = dpf.core.DataSources(server=server_type)
+    data_sources.set_result_file_path(cas_h5_file)
+    assert data_sources.result_key == "cas"
+    data_sources = dpf.core.DataSources(result_path=cas_h5_file, server=server_type)
+    assert data_sources.result_key == "cas"
+
+
+def test_set_resultpath_data_sources_cff(server_type):
+    from ansys.dpf.core import examples
+    cas_h5_file = examples.download_cfx_heating_coil(server=server_type)["cas"]
+    print(cas_h5_file)
+    data_sources = dpf.core.DataSources(server=server_type)
+    data_sources.set_result_file_path(cas_h5_file)
+    assert data_sources.result_key == "cas"
+    data_sources = dpf.core.DataSources(result_path=cas_h5_file, server=server_type)
+    assert data_sources.result_key == "cas"
+
+
 def test_addupstream_data_sources(allkindofcomplexity, server_type):
     data_sources = dpf.core.DataSources(server=server_type)
     data_sources2 = dpf.core.DataSources(server=server_type)


### PR DESCRIPTION
To better handle CFX and Fluent files with `.cas.cff`/`.dat.cff` or `.cas.h5`/`.dat.h5` extensions.