### PR TITLE
Fix a bug where a new server is run on object creation

### DIFF
--- a/src/ansys/dpf/core/any.py
+++ b/src/ansys/dpf/core/any.py
@@ -33,7 +33,9 @@ class Any:
 
     def __init__(self, any_dpf=None, server=None):
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            any_dpf._server if isinstance(any_dpf, Any) else server
+        )
 
         if any_dpf is None and not self._server.meet_version("7.0"):
             raise errors.DpfVersionNotSupported("7.0")

--- a/src/ansys/dpf/core/collection.py
+++ b/src/ansys/dpf/core/collection.py
@@ -33,7 +33,9 @@ class Collection(CollectionBase[TYPE]):
 
     def __init__(self, collection=None, server=None, entries_type: type = None):
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            collection._server if isinstance(collection, Collection) else server
+        )
         if not self._server.meet_version("8.1"):
             raise errors.DpfVersionNotSupported("8.1")
 

--- a/src/ansys/dpf/core/collection_base.py
+++ b/src/ansys/dpf/core/collection_base.py
@@ -46,7 +46,9 @@ class CollectionBase(Generic[TYPE]):
 
     def __init__(self, collection=None, server: BaseServer = None):
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            collection._server if isinstance(collection, CollectionBase) else server
+        )
 
         # step2: if object exists, take the instance, else create it
         self._internal_obj = None

--- a/src/ansys/dpf/core/config.py
+++ b/src/ansys/dpf/core/config.py
@@ -57,7 +57,9 @@ class Config:
 
     def __init__(self, operator_name=None, config=None, server=None, spec=None):
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            config._server if isinstance(config, Config) else server
+        )
 
         # step 2: get api
         self._api_instance = None  # see _api property

--- a/src/ansys/dpf/core/custom_type_field.py
+++ b/src/ansys/dpf/core/custom_type_field.py
@@ -93,7 +93,9 @@ class CustomTypeField(_FieldBase):
         """Initialize the field either with an optional field message or
         by connecting to a stub.
         """
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            field._server if isinstance(field, CustomTypeField) else server
+        )
         if field is None and not self._server.meet_version("5.0"):
             raise errors.DpfVersionNotSupported("5.0")
         if unitary_type is not None:

--- a/src/ansys/dpf/core/cyclic_support.py
+++ b/src/ansys/dpf/core/cyclic_support.py
@@ -45,7 +45,9 @@ class CyclicSupport:
     def __init__(self, cyclic_support, server=None):
         """Initialize time frequency support with its `TimeFreqSupport` message (if possible)."""
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            cyclic_support._server if isinstance(cyclic_support, CyclicSupport) else server
+        )
 
         # step 2: get api
         self._api = self._server.get_api_for_type(

--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -55,7 +55,9 @@ class DataSources:
     def __init__(self, result_path=None, data_sources=None, server=None):
         """Initialize a connection with the server."""
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            data_sources._server if isinstance(data_sources, DataSources) else server
+        )
 
         # step 2: get api
         self._api = self._server.get_api_for_type(

--- a/src/ansys/dpf/core/data_tree.py
+++ b/src/ansys/dpf/core/data_tree.py
@@ -84,7 +84,9 @@ class DataTree:
             "_holds_server",
         ]
         # step 1: get server
-        self._server_instance = server_module.get_or_create_server(server)
+        self._server_instance = server_module.get_or_create_server(
+            data_tree._server_instance if isinstance(data_tree, DataTree) else server
+        )
 
         if data_tree is None and not self._server.meet_version("4.0"):
             raise errors.DpfVersionNotSupported("4.0")

--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -103,7 +103,9 @@ class Operator:
         self._inputs = None
 
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            config._server if isinstance(config, Config) else server
+        )
 
         # step 2: get api
         self._api_instance = None  # see _api property

--- a/src/ansys/dpf/core/field_definition.py
+++ b/src/ansys/dpf/core/field_definition.py
@@ -32,7 +32,9 @@ class FieldDefinition:
 
     def __init__(self, field_definition=None, server=None):
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            field_definition._server if isinstance(field_definition, FieldDefinition) else server
+        )
 
         # step 2: get api
         self._api = self._server.get_api_for_type(

--- a/src/ansys/dpf/core/generic_data_container.py
+++ b/src/ansys/dpf/core/generic_data_container.py
@@ -43,7 +43,11 @@ class GenericDataContainer:
 
     def __init__(self, generic_data_container=None, server=None):
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            generic_data_container._server if isinstance(
+                generic_data_container, GenericDataContainer
+            ) else server
+        )
 
         if not self._server.meet_version("7.0"):
             raise errors.DpfVersionNotSupported("7.0")

--- a/src/ansys/dpf/core/label_space.py
+++ b/src/ansys/dpf/core/label_space.py
@@ -16,7 +16,9 @@ class LabelSpace:
     def __init__(self, label_space=None, obj=None, server=None):
         # ############################
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            label_space._server if isinstance(label_space, LabelSpace) else server
+        )
 
         # step 2: get api
         self._api = self._server.get_api_for_type(

--- a/src/ansys/dpf/core/meshed_region.py
+++ b/src/ansys/dpf/core/meshed_region.py
@@ -88,7 +88,9 @@ class MeshedRegion:
 
     def __init__(self, num_nodes=None, num_elements=None, mesh=None, server=None):
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            mesh._server if isinstance(mesh, MeshedRegion) else server
+        )
 
         # step 2: get api
         self._api = self._server.get_api_for_type(

--- a/src/ansys/dpf/core/operator_specification.py
+++ b/src/ansys/dpf/core/operator_specification.py
@@ -235,7 +235,9 @@ class Specification(SpecificationBase):
 
     def __init__(self, operator_name: Union[str, None]=None, specification: Union[Specification, None]=None, server: Union[server_module.BaseServer, None]=None):
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            specification._server if isinstance(specification, Specification) else server
+        )
 
         # step 2: get api
         self._api = self._server.get_api_for_type(

--- a/src/ansys/dpf/core/result_info.py
+++ b/src/ansys/dpf/core/result_info.py
@@ -106,7 +106,9 @@ class ResultInfo:
         """Initialize with a ResultInfo message"""
         # ############################
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            result_info._server if isinstance(result_info, ResultInfo) else server
+        )
 
         # step 2: get api
         self._api = self._server.get_api_for_type(

--- a/src/ansys/dpf/core/scoping.py
+++ b/src/ansys/dpf/core/scoping.py
@@ -63,10 +63,10 @@ class Scoping:
         by connecting to a stub.
         """
         # step 1: get server
-        if scoping:
-            self._server = scoping._server
-        else:
-            self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            scoping._server if isinstance(scoping, Scoping) else server
+        )
+
         self._api = self._server.get_api_for_type(
             capi=scoping_capi.ScopingCAPI, grpcapi=scoping_grpcapi.ScopingGRPCAPI
         )

--- a/src/ansys/dpf/core/scoping.py
+++ b/src/ansys/dpf/core/scoping.py
@@ -63,7 +63,10 @@ class Scoping:
         by connecting to a stub.
         """
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        if scoping:
+            self._server = scoping._server
+        else:
+            self._server = server_module.get_or_create_server(server)
         self._api = self._server.get_api_for_type(
             capi=scoping_capi.ScopingCAPI, grpcapi=scoping_grpcapi.ScopingGRPCAPI
         )

--- a/src/ansys/dpf/core/streams_container.py
+++ b/src/ansys/dpf/core/streams_container.py
@@ -40,7 +40,9 @@ class StreamsContainer:
 
     def __init__(self, streams_container=None, server: BaseServer = None):
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            streams_container._server if isinstance(streams_container, StreamsContainer) else server
+        )
         if self._server.has_client():
             txt = """
             StreamsContainer only available for server with InProcess communication protocol

--- a/src/ansys/dpf/core/string_field.py
+++ b/src/ansys/dpf/core/string_field.py
@@ -57,7 +57,9 @@ class StringField(_FieldBase):
         string_field=None,
         server=None,
     ):
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            string_field._server if isinstance(string_field, StringField) else server
+        )
         if string_field is None and not self._server.meet_version("5.0"):
             raise errors.DpfVersionNotSupported("5.0")
         super().__init__(

--- a/src/ansys/dpf/core/support.py
+++ b/src/ansys/dpf/core/support.py
@@ -44,7 +44,9 @@ class Support:
 
     def __init__(self, support, server=None):
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            support._server if isinstance(support, Support) else server
+        )
 
         if not self._server.meet_version("3.0"):  # pragma: no cover
             return

--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -70,7 +70,9 @@ class Workflow:
 
     def __init__(self, workflow=None, server=None):
         # step 1: get server
-        self._server = server_module.get_or_create_server(server)
+        self._server = server_module.get_or_create_server(
+            workflow._server if isinstance(workflow, Workflow) else server
+        )
 
         # step 2: get api
         self._api_instance = None  # see property self._api

--- a/tests/test_scoping.py
+++ b/tests/test_scoping.py
@@ -299,3 +299,17 @@ def test_mutable_ids_data(server_clayer):
     data = None
     changed_data = scop.ids
     assert np.allclose(changed_data[0], data_copy[0] + 2)
+
+
+def test_scoping_dont_start_server(server_type):
+    s = dpf.core.server._global_server()
+    dpf.core.SERVER = None
+    assert not dpf.core.server.has_local_server()
+    scop = Scoping(server=server_type)
+    assert not dpf.core.server.has_local_server()
+    ids = [1, 2, 3, 5, 8, 9, 10]
+    scop.ids = ids
+    scop = Scoping(scoping=scop)
+    assert not dpf.core.server.has_local_server()
+    assert np.allclose(scop.ids, ids)
+    dpf.core.SERVER = s


### PR DESCRIPTION
Creating a Python DPF object based on another Python DPF object triggered a new server instead of using the server of the object given as input. 