### PR TITLE
Get package version from library metadata

### DIFF
--- a/src/ansys/dpf/core/__init__.py
+++ b/src/ansys/dpf/core/__init__.py
@@ -1,8 +1,9 @@
 import os
 import pkg_resources
 
-from ansys.dpf.core._version import __version__
+import importlib.metadata as importlib_metadata
 
+__version__ = importlib_metadata.version(__name__.replace(".", "-"))
 
 # Setup data directory
 USER_DATA_PATH = None

--- a/src/ansys/dpf/core/__init__.py
+++ b/src/ansys/dpf/core/__init__.py
@@ -1,7 +1,10 @@
 import os
 import pkg_resources
 
-import importlib.metadata as importlib_metadata
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:  # Python < 3.10 (backport)
+    import importlib_metadata as importlib_metadata
 
 __version__ = importlib_metadata.version(__name__.replace(".", "-"))
 

--- a/src/ansys/dpf/core/__init__.py
+++ b/src/ansys/dpf/core/__init__.py
@@ -6,7 +6,7 @@ try:
 except ImportError:  # Python < 3.10 (backport)
     import importlib_metadata as importlib_metadata
 
-__version__ = importlib_metadata.version(__name__.replace(".", "-"))
+__version__ = importlib_metadata.version("ansys-dpf-core")
 
 # Setup data directory
 USER_DATA_PATH = None

--- a/src/ansys/dpf/core/_version.py
+++ b/src/ansys/dpf/core/_version.py
@@ -1,12 +1,4 @@
 """Version for ansys-dpf-core"""
-# major, minor, patch
-
-version_info = 0, 12, 3, "dev0"
-
-
-# Nice string for the version
-__version__ = ".".join(map(str, version_info))
-
 # Minimal DPF server version supported
 min_server_version = "4.0"
 

--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -21,8 +21,8 @@ import psutil
 
 import ansys.dpf.core as core
 from ansys.dpf.core.check_version import server_meet_version
-from ansys.dpf.core import errors, server_factory
-from ansys.dpf.core._version import min_server_version, server_to_ansys_version, __version__
+from ansys.dpf.core import errors, server_factory, __version__
+from ansys.dpf.core._version import min_server_version, server_to_ansys_version
 from ansys.dpf.core import server_context
 from ansys.dpf.gate import load_api, data_processing_grpcapi
 


### PR DESCRIPTION
This PR implements retrieval of the package's version from its metadata, as defined in the `pyproject.toml`, as is shown in the PyAnsys best practices.