### PR TITLE
Limit Numpy to <2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "google-api-python-client",
     "grpcio",
     "importlib-metadata >=4.0",
-    "numpy",
+    "numpy<2",
     "packaging",
     "protobuf",
     "psutil",


### PR DESCRIPTION
 while with bump all necessary dependencies to versions compatible with `NumPy 2.0.0` (PyVista, MatPlotLib...)