### PR TITLE
Require grpcio>=1.63.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "google-api-python-client",
-    "grpcio",
+    "grpcio >=1.63.0",
     "importlib-metadata >=4.0",
     "numpy<2",
     "packaging",


### PR DESCRIPTION
Following an error with lower versions:

`TypeError: Channel.unary_unary() got an unexpected keyword argument '_registered_method'`

