### PR TITLE
Update support for CentOS and Rocky 8

### DIFF
--- a/doc/source/getting_started/compatibility.rst
+++ b/doc/source/getting_started/compatibility.rst
@@ -7,8 +7,9 @@ Compatibility
 Operating system
 ----------------
 
-DPF supports Windows 10 and CentOS 7 and later. For
-more information, see `Ansys Platform Support <https://www.ansys.com/solutions/solutions-by-role/it-professionals/platform-support>`_.
+DPF supports Windows 10 and Rocky 8 and later.
+To run DPF on CentOS 7, use DPF for 2024R2 (8.2) or older.
+For more information, see `Ansys Platform Support <https://www.ansys.com/solutions/solutions-by-role/it-professionals/platform-support>`_.
 
 Client-server
 -------------

--- a/doc/source/getting_started/compatibility.rst
+++ b/doc/source/getting_started/compatibility.rst
@@ -7,7 +7,7 @@ Compatibility
 Operating system
 ----------------
 
-DPF supports Windows 10 and Rocky 8 and later.
+DPF supports Windows 10 and Rocky Linux 8 and later.
 To run DPF on CentOS 7, use DPF for 2024R2 (8.2) or older.
 For more information, see `Ansys Platform Support <https://www.ansys.com/solutions/solutions-by-role/it-professionals/platform-support>`_.
 


### PR DESCRIPTION
This PR updates the description of OS support by DPF in the documentation to mention drop of support for CentOS 7 and support starting from Rocky Linux 8.