### PR TITLE
Switch release CI to DPF 2025.1.pre0

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -11,11 +11,11 @@ on:
       ansys_version:
         description: "Ansys version of the standalone."
         required: false
-        default: '242'
+        default: '251'
       standalone_branch_suffix:
         description: 'Suffix of the branch on standalone'
         required: false
-        default: '.pre1'
+        default: '.pre0'
 
 #┌───────────── minute (0 - 59)
 #│ ┌───────────── hour (0 - 23)
@@ -77,38 +77,38 @@ jobs:
   tests:
     uses: ./.github/workflows/tests.yml
     with:
-      ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '242' }}
+      ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '251' }}
       python_versions: '["3.9", "3.10", "3.11"]'
       wheel: true
       wheelhouse: true
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre1' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
     secrets: inherit
 
   tests_any:
     uses: ./.github/workflows/tests.yml
     with:
-      ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '242' }}
+      ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '251' }}
       python_versions: '["3.9", "3.10", "3.11"]'
       wheel: true
       wheelhouse: false
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre1' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
       test_any: true
     secrets: inherit
 
   docs:
     uses: ./.github/workflows/docs.yml
     with:
-      ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '242' }}
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre1' }}
+      ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '251' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
       event_name: ${{ github.event_name }}
     secrets: inherit
 
   examples:
     uses: ./.github/workflows/examples.yml
     with:
-      ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '242' }}
+      ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '251' }}
       python_versions: '["3.9", "3.10", "3.11"]'
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre1' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
     secrets: inherit
 
   retro_241:
@@ -148,13 +148,20 @@ jobs:
       DOCSTRING: false
     secrets: inherit
 
+  pydpf-post_251:
+    name: "PyDPF-Post with 251"
+    uses: ./.github/workflows/pydpf-post.yml
+    with:
+      ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '251' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
+      test_docstrings: "true"
+    secrets: inherit
+
   pydpf-post_242:
     name: "PyDPF-Post with 242"
     uses: ./.github/workflows/pydpf-post.yml
     with:
-      ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '242' }}
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre1' }}
-      test_docstrings: "true"
+      ANSYS_VERSION: "242"
     secrets: inherit
 
   pydpf-post_241:
@@ -189,17 +196,17 @@ jobs:
     name: "Build and Test on Docker"
     uses: ./.github/workflows/test_docker.yml
     with:
-      ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '242' }}
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre1' }}
+      ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '251' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
     secrets: inherit
 
   docker_examples:
     name: "Run examples on Docker"
     uses: ./.github/workflows/examples_docker.yml
     with:
-      ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '242' }}
+      ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '251' }}
       python_versions: '["3.9", "3.10", "3.11"]'
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre1' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
     secrets: inherit
 
   draft_release:


### PR DESCRIPTION
Bump release testing to DPF 2025.1.pre0 planned for next week.
Release CI action: https://github.com/ansys/pydpf-core/actions/runs/9987868674