### PR TITLE
Add 9.1 to prepare for post-release

### DIFF
--- a/src/ansys/dpf/core/_version.py
+++ b/src/ansys/dpf/core/_version.py
@@ -19,6 +19,7 @@ class ServerToAnsysVersion:
         "8.1": "2024R2",
         "8.2": "2024R2",
         "9.0": "2025R1",
+        "9.1": "2025R1",
     }
 
     def __getitem__(self, item):


### PR DESCRIPTION
Add "9.1" version to be able to merge the bump to 2025.1.pre1 in the server