### PR TITLE
Fix CI release main python version envvar

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -29,7 +29,6 @@ on:
 
 env:
   DOCUMENTATION_CNAME: 'dpf.docs.pyansys.com'
-  MAIN_PYTHON_VERSION: '3.9'
 
 jobs:
   debug:
@@ -79,7 +78,7 @@ jobs:
     with:
       ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '251' }}
       python_versions: '["3.9", "3.10", "3.11"]'
-      wheel: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION }}
+      wheel: ${{ matrix.python-version == '3.9' }}
       wheelhouse: true
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
     secrets: inherit
@@ -89,7 +88,7 @@ jobs:
     with:
       ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '251' }}
       python_versions: '["3.9", "3.10", "3.11"]'
-      wheel: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION }}
+      wheel: ${{ matrix.python-version == '3.9' }}
       wheelhouse: false
       standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
       test_any: true


### PR DESCRIPTION
This started being an [issue](https://github.com/ansys/pydpf-core/actions/runs/10654274290) for some reason.
Checked again [online](https://github.com/orgs/community/discussions/26529) and this is not officially supported for reusable workflows (not to confuse with composite actions).
Hard-coding the values instead.
This is weird as this had been working for some time.