### PR TITLE
Add new DPF versions to the bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -61,6 +61,8 @@ body:
       label: Which DPF/Ansys version are you using?
       multiple: true
       options:
+       - 'DPF Server 2025.1.pre0'
+       - 'Ansys 2024 R2'
        - 'DPF Server 2024.2.pre1'
        - 'DPF Server 2024.2.pre0'
        - 'Ansys 2024 R1'
@@ -89,6 +91,7 @@ body:
        - '3.10'
        - '3.11'
        - '3.12'
+       - '3.13'
     validations:
       required: true
 


### PR DESCRIPTION
Adds options:
- ANSYS 2024 R2
- DPF 2025.1.pre0

as well as:
- Python 3.13