### PR TITLE
Take ownership of ansys/dpf/gate/*grpcapi.py files

### DIFF
--- a/.ci/update_dpf_dependencies.py
+++ b/.ci/update_dpf_dependencies.py
@@ -66,10 +66,9 @@ if gate_path is not None:
     print(f"from {dist_path}")
     destination = os.path.join(core_path, "src", "ansys", "dpf", "gate", "__init__.py")
     print(f"into {destination}")
-    shutil.copytree(
+    shutil.copy(
         src=dist_path,
         dst=destination,
-        dirs_exist_ok=True,
     )
     print("Done updating ansys.dpf.gate generated code")
 

--- a/.ci/update_dpf_dependencies.py
+++ b/.ci/update_dpf_dependencies.py
@@ -62,6 +62,15 @@ if gate_path is not None:
         dirs_exist_ok=True,
         ignore=lambda directory, contents: ["__pycache__"] if directory[-5:] == "gate" else [],
     )
+    dist_path = os.path.join(gate_path, "ansys-dpf-gate", "ansys", "dpf", "gate", "__init__.py")
+    print(f"from {dist_path}")
+    destination = os.path.join(core_path, "src", "ansys", "dpf", "gate", "__init__.py")
+    print(f"into {destination}")
+    shutil.copytree(
+        src=dist_path,
+        dst=destination,
+        dirs_exist_ok=True,
+    )
     print("Done updating ansys.dpf.gate generated code")
 
     # Update ansys-dpf-gatebin

--- a/.ci/update_dpf_dependencies.py
+++ b/.ci/update_dpf_dependencies.py
@@ -1,4 +1,4 @@
-"""Script to update ansys-dpf-gate, ansys-dpf-gatebin and ansys-grpc-dpf based on repositories
+"""Script to update ansys.dpf.gate.generated, ansys.dpf.gatebin and ansys.grpc.dpf.
 
 This script should only be used to quickly test changes to any of these dependencies.
 Actual commit of updated code should not occur.
@@ -45,16 +45,16 @@ if grpc_path is not None:
                     file,
                     path=destination,
                 )
-    print("Done updating ansys-grpc-dpf")
+    print("Done updating ansys.grpc.dpf")
 else:
     print(f"{grpc_path_key} environment variable is not defined. " "Cannot update ansys-grpc-dpf.")
 
 if gate_path is not None:
     # Update ansys-dpf-gate
-    print("Updating ansys.dpf.gate")
-    dist_path = os.path.join(gate_path, "ansys-dpf-gate", "ansys")
+    print("Updating ansys.dpf.gate generated code")
+    dist_path = os.path.join(gate_path, "ansys-dpf-gate", "ansys", "dpf", "gate", "generated")
     print(f"from {dist_path}")
-    destination = os.path.join(core_path, "src", "ansys")
+    destination = os.path.join(core_path, "src", "ansys", "dpf", "gate", "generated")
     print(f"into {destination}")
     shutil.copytree(
         src=dist_path,
@@ -62,7 +62,7 @@ if gate_path is not None:
         dirs_exist_ok=True,
         ignore=lambda directory, contents: ["__pycache__"] if directory[-5:] == "gate" else [],
     )
-    print("Done updating ansys-dpf-gate")
+    print("Done updating ansys.dpf.gate generated code")
 
     # Update ansys-dpf-gatebin
     print("Updating ansys.dpf.gatebin")
@@ -75,9 +75,9 @@ if gate_path is not None:
         dst=destination,
         dirs_exist_ok=True,
     )
-    print(f"Done updating ansys-dpf-gatebin for {platform.system()}")
+    print(f"Done updating ansys.dpf.gatebin for {platform.system()}")
 else:
     print(
         f"{gate_path_key} environment variable is not defined. "
-        "Cannot update ansys-dpf-gate or ansys-dpf-gatebin."
+        "Cannot update ansys.dpf.gate or ansys.dpf.gatebin."
     )

--- a/.github/workflows/update_operators.yml
+++ b/.github/workflows/update_operators.yml
@@ -66,10 +66,10 @@ jobs:
         run: |
           wheel_file=$(find ./dpf-standalone/v${{ github.event.inputs.ANSYS_VERSION }}/dist -name "ansys_dpf_gate-*"  -type f)
           echo $wheel_file
-          rm -r src/ansys/dpf/gate
-          unzip -o $wheel_file "ansys/**/*" -d src/
-          chmod -R 777 src/ansys/dpf/gate
-          git add -f src/ansys/dpf/gate
+          rm -r src/ansys/dpf/gate/generated
+          unzip -o $wheel_file "ansys/dpf/gate/generated/*" -d src/ansys/dpf/gate/generated
+          chmod -R 777 src/ansys/dpf/gate/generated
+          git add -f src/ansys/dpf/gate/generated
 
       - name: "Update ansys-dpf-gatebin lin"
         shell: bash

--- a/.github/workflows/update_operators.yml
+++ b/.github/workflows/update_operators.yml
@@ -68,8 +68,9 @@ jobs:
           echo $wheel_file
           rm -r src/ansys/dpf/gate/generated
           unzip -o $wheel_file "ansys/dpf/gate/generated/*" -d src/ansys/dpf/gate/generated
-          chmod -R 777 src/ansys/dpf/gate/generated
-          git add -f src/ansys/dpf/gate/generated
+          unzip -o $wheel_file "ansys/dpf/gate/__init__.py" -d src/ansys/dpf/gate
+          chmod -R 777 src/ansys/dpf/gate
+          git add -f src/ansys/dpf/gate
 
       - name: "Update ansys-dpf-gatebin lin"
         shell: bash

--- a/.github/workflows/update_operators.yml
+++ b/.github/workflows/update_operators.yml
@@ -67,8 +67,8 @@ jobs:
           wheel_file=$(find ./dpf-standalone/v${{ github.event.inputs.ANSYS_VERSION }}/dist -name "ansys_dpf_gate-*"  -type f)
           echo $wheel_file
           rm -r src/ansys/dpf/gate/generated
-          unzip -o $wheel_file "ansys/dpf/gate/generated/*" -d src/ansys/dpf/gate/generated
-          unzip -o $wheel_file "ansys/dpf/gate/__init__.py" -d src/ansys/dpf/gate
+          unzip -o $wheel_file "ansys/dpf/gate/generated/*" -d src/
+          unzip -o $wheel_file "ansys/dpf/gate/__init__.py" -d src/
           chmod -R 777 src/ansys/dpf/gate
           git add -f src/ansys/dpf/gate
 


### PR DESCRIPTION
A first PR to stop updating `ansys/dpf/gate/*_grpcapi.py` files when getting code updates from new servers.
This PR means that PyDPF-Core would now have ownership of these files.

Example run of code update:
https://github.com/ansys/pydpf-core/actions/runs/10698323848/job/29657450211