### PR TITLE
Fix connecting StreamsContainer as input or output of Operator or Workflow when InProcess

### DIFF
--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -473,9 +473,11 @@ class Operator:
             model,
             generic_data_container,
             any,
+            streams_container,
         )
 
         out = [
+            (streams_container.StreamsContainer, self._api.operator_connect_streams),
             (any.Any, self._api.operator_connect_any),
             (bool, self._api.operator_connect_bool),
             ((int, Enum), self._api.operator_connect_int),

--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -309,9 +309,11 @@ class Workflow:
             generic_data_container,
             any,
             collection_base,
+            streams_container,
         )
 
         out = [
+            (streams_container.StreamsContainer, self._api.work_flow_getoutput_streams),
             (any.Any, self._api.work_flow_getoutput_as_any),
             (bool, self._api.work_flow_getoutput_bool),
             (int, self._api.work_flow_getoutput_int),

--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -242,9 +242,11 @@ class Workflow:
             model,
             generic_data_container,
             any,
+            streams_container,
         )
 
         out = [
+            (streams_container.StreamsContainer, self._api.work_flow_connect_streams),
             (any.Any, self._api.work_flow_connect_any),
             (bool, self._api.work_flow_connect_bool),
             ((int, Enum), self._api.work_flow_connect_int),

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1381,3 +1381,14 @@ def test_input_any(server_type):
     output = op.get_output(pin=0, output_type=dpf.core.types.field)
     assert isinstance(output, dpf.core.Field)
     assert len(output.data_as_list) == len(data)
+
+
+def test_operator_input_output_streams(server_type, simple_bar):
+    data_source = dpf.core.DataSources(simple_bar, server=server_type)
+    streams_op = dpf.core.operators.metadata.streams_provider(server=server_type)
+    streams_op.inputs.data_sources.connect(data_source)
+    streams = streams_op.outputs.streams_container()
+    time_provider = dpf.core.operators.metadata.time_freq_provider(server=server_type)
+    time_provider.connect(pin=3, inpt=streams)
+    times = time_provider.outputs.time_freq_support()
+    assert times

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1384,11 +1384,11 @@ def test_input_any(server_type):
 
 
 def test_operator_input_output_streams(server_in_process, simple_bar):
-    data_source = dpf.core.DataSources(simple_bar, server=server_type)
-    streams_op = dpf.core.operators.metadata.streams_provider(server=server_type)
+    data_source = dpf.core.DataSources(simple_bar, server=server_in_process)
+    streams_op = dpf.core.operators.metadata.streams_provider(server=server_in_process)
     streams_op.inputs.data_sources.connect(data_source)
     streams = streams_op.outputs.streams_container()
-    time_provider = dpf.core.operators.metadata.time_freq_provider(server=server_type)
+    time_provider = dpf.core.operators.metadata.time_freq_provider(server=server_in_process)
     time_provider.connect(pin=3, inpt=streams)
     times = time_provider.outputs.time_freq_support()
     assert times

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1383,6 +1383,10 @@ def test_input_any(server_type):
     assert len(output.data_as_list) == len(data)
 
 
+@pytest.mark.skipif(
+    condition=not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_0,
+    reason="Input/output of Streams requires DPF 6.0 or above.",
+)
 def test_operator_input_output_streams(server_in_process, simple_bar):
     data_source = dpf.core.DataSources(simple_bar, server=server_in_process)
     streams_op = dpf.core.operators.metadata.streams_provider(server=server_in_process)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1383,7 +1383,7 @@ def test_input_any(server_type):
     assert len(output.data_as_list) == len(data)
 
 
-def test_operator_input_output_streams(server_type, simple_bar):
+def test_operator_input_output_streams(server_in_process, simple_bar):
     data_source = dpf.core.DataSources(simple_bar, server=server_type)
     streams_op = dpf.core.operators.metadata.streams_provider(server=server_type)
     streams_op.inputs.data_sources.connect(data_source)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -983,7 +983,7 @@ def test_input_any(server_type):
     assert isinstance(output, dpf.core.Field)
 
 
-def test_workflow_input_output_streams(server_type, simple_bar):
+def test_workflow_input_output_streams(server_in_process, simple_bar):
     data_source = dpf.core.DataSources(simple_bar, server=server_type)
     streams_op = dpf.core.operators.metadata.streams_provider(server=server_type)
     streams_op.inputs.data_sources.connect(data_source)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -983,6 +983,27 @@ def test_input_any(server_type):
     assert isinstance(output, dpf.core.Field)
 
 
+def test_workflow_input_output_streams(server_type, simple_bar):
+    data_source = dpf.core.DataSources(simple_bar, server=server_type)
+    streams_op = dpf.core.operators.metadata.streams_provider(server=server_type)
+    streams_op.inputs.data_sources.connect(data_source)
+    wf_1 = dpf.core.Workflow(server=server_type)
+    wf_1.add_operator(streams_op)
+    wf_1.set_output_name("output_streams", streams_op.outputs.streams_container)
+
+    streams = wf_1.get_output("output_streams", dpf.core.types.streams_container)
+
+    time_provider = dpf.core.operators.metadata.time_freq_provider(server=server_type)
+
+    wf_2 = dpf.core.Workflow(server=server_type)
+    wf_2.add_operator(time_provider)
+    wf_2.set_input_name("input_streams", time_provider.inputs.streams_container)
+    wf_2.set_output_name("output_tfs", time_provider.outputs.time_freq_support)
+    wf_2.connect("input_streams", streams)
+    times = wf_2.get_output("output_tfs", dpf.core.types.time_freq_support)
+    assert times
+
+
 def main():
     test_connect_field_workflow()
     velocity_acceleration = conftest.resolve_test_file("velocity_acceleration.rst", "rst_operators")

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -984,18 +984,18 @@ def test_input_any(server_type):
 
 
 def test_workflow_input_output_streams(server_in_process, simple_bar):
-    data_source = dpf.core.DataSources(simple_bar, server=server_type)
-    streams_op = dpf.core.operators.metadata.streams_provider(server=server_type)
+    data_source = dpf.core.DataSources(simple_bar, server=server_in_process)
+    streams_op = dpf.core.operators.metadata.streams_provider(server=server_in_process)
     streams_op.inputs.data_sources.connect(data_source)
-    wf_1 = dpf.core.Workflow(server=server_type)
+    wf_1 = dpf.core.Workflow(server=server_in_process)
     wf_1.add_operator(streams_op)
     wf_1.set_output_name("output_streams", streams_op.outputs.streams_container)
 
     streams = wf_1.get_output("output_streams", dpf.core.types.streams_container)
 
-    time_provider = dpf.core.operators.metadata.time_freq_provider(server=server_type)
+    time_provider = dpf.core.operators.metadata.time_freq_provider(server=server_in_process)
 
-    wf_2 = dpf.core.Workflow(server=server_type)
+    wf_2 = dpf.core.Workflow(server=server_in_process)
     wf_2.add_operator(time_provider)
     wf_2.set_input_name("input_streams", time_provider.inputs.streams_container)
     wf_2.set_output_name("output_tfs", time_provider.outputs.time_freq_support)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -983,6 +983,10 @@ def test_input_any(server_type):
     assert isinstance(output, dpf.core.Field)
 
 
+@pytest.mark.skipif(
+    condition=not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_0,
+    reason="Input/output of Streams requires DPF 6.0 or above.",
+)
 def test_workflow_input_output_streams(server_in_process, simple_bar):
     data_source = dpf.core.DataSources(simple_bar, server=server_in_process)
     streams_op = dpf.core.operators.metadata.streams_provider(server=server_in_process)


### PR DESCRIPTION
The `StreamsContainer` cannot currently be instantiated or manipulated for a remote server via gRPC.

It looks like it is by design but I do not see why that would be.

This prevents from running a script working when `InProcess`, on a `gRPC` type server, if it contains any `StreamsContainer` instance.


We do for example have operators which take a `StreamsContainer` as input or provide one as output. Those can't be fed back into other operators.