### PR TITLE
changes in the sidebar of the examples section

### DIFF
--- a/doc/source/_templates/custom_examples.html
+++ b/doc/source/_templates/custom_examples.html
@@ -1,0 +1,36 @@
+<div class="sidebar-primary-items__start sidebar-primary__section">
+        <div class="sidebar-primary-item">
+<nav class="bd-docs-nav bd-links" aria-label="Section Navigation">
+  <p class="bd-links__title" role="heading" aria-level="1">Section Navigation</p>
+  <div class="bd-toc-item navbar-nav">
+    <p style="font-weight:bold;" aria-label="Fundamentals" role="heading" aria-level="2">Fundamentals</p>
+    <ul class="nav bd-sidenav">
+      <li class="toctree-l1"><a class="reference internal" href="00-basic/index.html">Basic DPF examples</a></li>
+    </ul>
+      <p style="font-weight:bold;" aria-label="Intermediate" role="heading" aria-level="2">Intermediate</p> <ul class="nav bd-sidenav">
+      <li class="toctree-l1"><a class="reference internal" href="01-transient_analyses/index.html">Transient analysis examples</a></li>
+      <li class="toctree-l1"><a class="reference internal" href="02-modal_analyses/index.html">Modal analysis examples</a></li>
+      <li class="toctree-l1"><a class="reference internal" href="03-harmonic_analyses/index.html">Harmonic analysis examples</a></li>
+      <li class="toctree-l1"><a class="reference internal" href="04-advanced/index.html">Advanced and miscellaneous examples</a></li>
+      <li class="toctree-l1"><a class="reference internal" href="05-file-IO/index.html">File manipulation and input-output examples</a></li>
+      <li class="toctree-l1"><a class="reference internal" href="06-plotting/index.html">Plotting examples</a></li>
+      <li class="toctree-l1"><a class="reference internal" href="07-distributed-post/index.html">Examples for postprocessing on distributed processes</a></li>
+      <li class="toctree-l1"><a class="reference internal" href="08-python-operators/index.html">Examples of creating custom operator plugins</a></li>
+      <li class="toctree-l1"><a class="reference internal" href="09-averaging/index.html">Averaging examples</a></li>
+      <li class="toctree-l1"><a class="reference internal" href="10-mesh_operations/index.html">Mesh operations examples</a></li>
+      <li class="toctree-l1"><a class="reference internal" href="11-cyclic-symmetry/index.html">Cyclic symmetry examples</a></li>
+    </ul>
+    <p style="font-weight:bold;" aria-label="Advanced" role="heading" aria-level="2">Advanced</p> <ul class="nav bd-sidenav">
+      <li class="toctree-l1"><a class="reference internal" href="12-fluids/index.html">Fluids examples</a></li>
+      <li class="toctree-l1"><a class="reference internal" href="13-streamlines/index.html">Streamlines examples</a></li>
+      <li class="toctree-l1"><a class="reference internal" href="14-lsdyna/index.html">LS-Dyna examples</a></li>
+      <li class="toctree-l1"><a class="reference internal" href="15-cfx/index.html">CFX examples</a></li>
+    </ul>
+  </div>
+</nav>
+</div>
+    </div>
+
+
+  <div class="sidebar-primary-items__end sidebar-primary__section">
+  </div>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -108,7 +108,7 @@ autosummary_generate = True
 autodoc_mock_imports = ["ansys.dpf.core.examples.python_plugins"]
 
 # Add any paths that contain templates here, relative to this directory.
-# templates_path = ['_templates']
+templates_path = ['_templates']
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -237,7 +237,9 @@ html_css_files = [
 #
 # html_sidebars = {}
 
-html_sidebars = {"testing": []}
+html_sidebars = {"testing": [],
+                 "examples/**": ["custom_examples"],
+                 }
 
 
 # -- Options for HTMLHelp output ---------------------------------------------


### PR DESCRIPTION
This PR changes the sidebar in the examples web page:

- Add subtitles
![image](https://github.com/user-attachments/assets/eae4b429-8770-40dc-9114-3e3483eb280f)
