### PR TITLE
Improvements to the release notes template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,19 +1,24 @@
 changelog:
-    categories:
-      - title: Enhancements
-        labels:
-          - enhancement
-      - title: Bug fixes
-        labels:
-          - bug
-      - title: Documentation
-        labels:
-          - documentation
-          - examples
-      - title: CI/CD
-        labels:
-          - CI/CD
-      - title: Maintenance
-        labels:
-          - maintenance
-          - dependencies
+  exclude:
+    authors:
+      - dependabot[bot]
+  categories:
+    - title: Enhancements
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Examples
+      labels:
+        - examples
+    - title: CI/CD
+      labels:
+        - CI/CD
+    - title: Maintenance
+      labels:
+        - maintenance
+        - dependencies


### PR DESCRIPTION
Exclude `dependabot` from release notes and separate the Examples section from the Documentation section.