### PR TITLE
fix: enable isort and apply it to the library

### DIFF
--- a/.ci/build_wheel.py
+++ b/.ci/build_wheel.py
@@ -2,12 +2,11 @@
 # Input can be one of ["any", "win", "manylinux1", "manylinux_2_17"]
 
 import argparse
-import subprocess
 import os
-import sys
 import shutil
+import subprocess
+import sys
 import tempfile
-
 
 supported_platforms = {
     "any": "any",

--- a/.ci/code_generation.py
+++ b/.ci/code_generation.py
@@ -1,13 +1,13 @@
 # import subprocess
 
+import glob
+import os
+from pathlib import Path
+import shutil
+import time
+
 from ansys.dpf import core
 from ansys.dpf.core.operators import build
-import os
-import glob
-from pathlib import Path
-import time
-import shutil
-
 
 core.set_default_server_context(core.AvailableServerContexts.premium)
 

--- a/.ci/run_examples.py
+++ b/.ci/run_examples.py
@@ -1,12 +1,11 @@
-import os
 import glob
+import os
 import pathlib
 import subprocess
 import sys
 
 import ansys.dpf.core as dpf
 from ansys.dpf.core.examples import get_example_required_minimum_dpf_version
-
 
 os.environ["PYVISTA_OFF_SCREEN"] = "true"
 os.environ["MPLBACKEND"] = "Agg"

--- a/.ci/run_non_regression_examples.py
+++ b/.ci/run_non_regression_examples.py
@@ -1,9 +1,10 @@
-import os
 import glob
-from ansys.dpf import core
+import os
 import pathlib
 import subprocess
 import sys
+
+from ansys.dpf import core
 
 os.environ["PYVISTA_OFF_SCREEN"] = "true"
 os.environ["MPLBACKEND"] = "Agg"

--- a/.ci/update_dpf_dependencies.py
+++ b/.ci/update_dpf_dependencies.py
@@ -13,13 +13,12 @@ It will update the current repo
 or the repo defined by the environment variable "ANSYSDPFCORE_ROOT" if it exists.
 """
 
-import os
 import glob
+import os
 import pathlib
 import platform
 import shutil
 import zipfile
-
 
 grpc_path_key = "DPFDV_ROOT"
 gate_path_key = "ANSYSDPFPYGATE_ROOT"

--- a/examples/00-basic/05-use_local_data.py
+++ b/examples/00-basic/05-use_local_data.py
@@ -36,9 +36,7 @@ in one transaction.
 
 # Import necessary modules
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
-
+from ansys.dpf.core import examples, operators as ops
 
 ###############################################################################
 # Create a model object to establish a connection with an

--- a/examples/00-basic/11-server_types.py
+++ b/examples/00-basic/11-server_types.py
@@ -53,6 +53,7 @@ To change the default type of server's configuration used by DPF change:
 """
 
 import os
+
 from ansys.dpf import core as dpf
 
 ###############################################################################

--- a/examples/01-transient_analyses/00-basic_transient.py
+++ b/examples/01-transient_analyses/00-basic_transient.py
@@ -37,8 +37,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
+from ansys.dpf.core import examples, operators as ops
 
 ###############################################################################
 # Download the transient result example. This example is

--- a/examples/01-transient_analyses/01-transient_easy_time_scoping.py
+++ b/examples/01-transient_analyses/01-transient_easy_time_scoping.py
@@ -34,8 +34,7 @@ This example shows how to use a model's result to choose a time scoping.
 import matplotlib.pyplot as plt
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
+from ansys.dpf.core import examples, operators as ops
 
 ###############################################################################
 # Create the model and display the state of the result. This transient result

--- a/examples/02-modal_analyses/01-plot_and_animate_modes.py
+++ b/examples/02-modal_analyses/01-plot_and_animate_modes.py
@@ -32,8 +32,7 @@ and how to plot and animate them.
 """
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import animation
-from ansys.dpf.core import examples
+from ansys.dpf.core import animation, examples
 
 ###############################################################################
 # Retrieve mode shapes

--- a/examples/03-harmonic_analyses/00-multi_harmonic.py
+++ b/examples/03-harmonic_analyses/00-multi_harmonic.py
@@ -34,9 +34,7 @@ using ``fft`` transformations.
 import matplotlib.pyplot as pyplot
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
-
+from ansys.dpf.core import examples, operators as ops
 
 ###############################################################################
 # Begin by downloading the example harmonic result. This result is

--- a/examples/03-harmonic_analyses/01-modal_superposition.py
+++ b/examples/03-harmonic_analyses/01-modal_superposition.py
@@ -38,7 +38,6 @@ reduces the size of the result files.
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
-
 ###############################################################################
 # Create data sources
 # ~~~~~~~~~~~~~~~~~~~

--- a/examples/04-advanced/00-multistage_advanced_options.py
+++ b/examples/04-advanced/00-multistage_advanced_options.py
@@ -32,8 +32,7 @@ for advanced postprocessing
 """
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
+from ansys.dpf.core import examples, operators as ops
 
 ###############################################################################
 # Create the model and display the state of the result.

--- a/examples/04-advanced/01-solve_harmonic_problem.py
+++ b/examples/04-advanced/01-solve_harmonic_problem.py
@@ -37,7 +37,6 @@ import math
 from ansys.dpf import core as dpf
 from ansys.dpf.core import operators as ops
 
-
 ###############################################################################
 # Create 2D (x,y) matrix fields for inertia, damping, and stiffness.
 

--- a/examples/04-advanced/02-volume_averaged_stress.py
+++ b/examples/04-advanced/02-volume_averaged_stress.py
@@ -35,9 +35,7 @@ total volume.
 """
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
-
+from ansys.dpf.core import examples, operators as ops
 
 ###############################################################################
 # Create a model targeting a given result file

--- a/examples/04-advanced/03-exchange_data_between_servers.py
+++ b/examples/04-advanced/03-exchange_data_between_servers.py
@@ -35,9 +35,7 @@ without any more difficulties than working on a local computer.
 """
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
-
+from ansys.dpf.core import examples, operators as ops
 
 ###############################################################################
 # Create two servers

--- a/examples/04-advanced/04-extrapolation_stress_3d.py
+++ b/examples/04-advanced/04-extrapolation_stress_3d.py
@@ -57,7 +57,6 @@ Here are the steps for extrapolation:
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
-
 ###############################################################################
 # Get the data source's analysis of integration points and analysis reference
 datafile = examples.download_extrapolation_3d_result()

--- a/examples/04-advanced/05-extrapolation_strain_2d.py
+++ b/examples/04-advanced/05-extrapolation_strain_2d.py
@@ -57,7 +57,6 @@ Here are the steps for extrapolation:
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
-
 ###############################################################################
 # Get the data source's analyse of integration points and data source's analyse reference
 datafile = examples.download_extrapolation_2d_result()

--- a/examples/04-advanced/06-stress_gradient_path.py
+++ b/examples/04-advanced/06-stress_gradient_path.py
@@ -41,10 +41,8 @@ A path is created of a defined length.
 import matplotlib.pyplot as plt
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
+from ansys.dpf.core import examples, operators as ops
 from ansys.dpf.core.plotter import DpfPlotter
-
 
 ###############################################################################
 # Open an example and print out the ``Model`` object. The

--- a/examples/04-advanced/07-load_plugin.py
+++ b/examples/04-advanced/07-load_plugin.py
@@ -34,7 +34,6 @@ This example shows how to load a plugin that is not loaded automatically.
 # Import DPF-Core:
 from ansys.dpf import core as dpf
 
-
 server = dpf.global_server()
 
 ###############################################################################

--- a/examples/04-advanced/11-cycles_to_failure.py
+++ b/examples/04-advanced/11-cycles_to_failure.py
@@ -53,9 +53,10 @@ The cycles to failure result is the (interpolated) negative of the stress result
 The higher the stress result, the lower the number of cycles to failure.
 """
 
+import numpy as np
+
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
-import numpy as np
 
 ###############################################################################
 # The first step is to generate a simple model with high stress

--- a/examples/04-advanced/14-incremental_evaluation.py
+++ b/examples/04-advanced/14-incremental_evaluation.py
@@ -33,7 +33,6 @@ This example shows you how to use the incremental evaluation helper.
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
-
 #######################################################################################
 # Retrieve an example to instantiate a DataSources object
 path = examples.download_transient_result()

--- a/examples/05-file-IO/00-hdf5_double_float_comparison.py
+++ b/examples/05-file-IO/00-hdf5_double_float_comparison.py
@@ -39,8 +39,7 @@ compare simple precision versus double precision.
 import os
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
+from ansys.dpf.core import examples, operators as ops
 
 ###############################################################################
 # Create the model and get the stresses, displacements, and mesh.

--- a/examples/05-file-IO/01-reduced_matrices_export.py
+++ b/examples/05-file-IO/01-reduced_matrices_export.py
@@ -36,8 +36,7 @@ export them to HDF5 and CSV files.
 # temporary directory.
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
+from ansys.dpf.core import examples, operators as ops
 
 ###############################################################################
 # Create the operator and connect data sources.

--- a/examples/05-file-IO/04-basic-load-file.py
+++ b/examples/05-file-IO/04-basic-load-file.py
@@ -40,7 +40,6 @@ exported to a CSV file.
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
-
 model = dpf.Model(examples.find_simple_bar())
 mesh = model.metadata.meshed_region
 

--- a/examples/06-plotting/00-basic_plotting.py
+++ b/examples/06-plotting/00-basic_plotting.py
@@ -34,7 +34,6 @@ shown with the arguments available.
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
-
 # Plot the bare mesh of a model
 model = dpf.Model(examples.find_multishells_rst())
 model.plot(color="w", show_edges=True, title="Model", text="Model plot")

--- a/examples/06-plotting/04-plot_on_path.py
+++ b/examples/06-plotting/04-plot_on_path.py
@@ -35,10 +35,8 @@ and how to plot it.
 import matplotlib.pyplot as plt
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
+from ansys.dpf.core import examples, operators as ops
 from ansys.dpf.core.plotter import DpfPlotter
-
 
 ###############################################################################
 # Plot path

--- a/examples/06-plotting/05-plot_on_warped_mesh.py
+++ b/examples/06-plotting/05-plot_on_warped_mesh.py
@@ -34,7 +34,6 @@ enabling to plot on the deformed geometry.
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
-
 # Get and show the initial model
 model = dpf.Model(examples.find_multishells_rst())
 print(model)

--- a/examples/06-plotting/06-animate_results.py
+++ b/examples/06-plotting/06-animate_results.py
@@ -34,7 +34,6 @@ shown with the arguments available.
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
-
 # Load the model
 model = dpf.Model(examples.find_msup_transient())
 print(model)

--- a/examples/06-plotting/07-plot_on_geometries.py
+++ b/examples/06-plotting/07-plot_on_geometries.py
@@ -36,16 +36,14 @@ objects such as points, lines and planes.
 # ~~~~~~~~~~~~~~~~~~~~~~
 # Import modules and set context as Premium.
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
+from ansys.dpf.core import examples, operators as ops
+from ansys.dpf.core.fields_factory import field_from_array
 from ansys.dpf.core.geometry import Line, Plane, Points
 from ansys.dpf.core.plotter import DpfPlotter
-from ansys.dpf.core.fields_factory import field_from_array
-
 
 ###############################################################################
 # Load model from examples and print information:

--- a/examples/07-distributed-post/00-distributed_total_disp.py
+++ b/examples/07-distributed-post/00-distributed_total_disp.py
@@ -73,9 +73,9 @@ the operator chain that is used to compute the final result.
 # Import the ``dpf-core`` module and its examples files.
 
 import os
+
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
+from ansys.dpf.core import examples, operators as ops
 
 ###############################################################################
 # Configure the servers.

--- a/examples/07-distributed-post/01-distributed_workflows_on_remote.py
+++ b/examples/07-distributed-post/01-distributed_workflows_on_remote.py
@@ -71,9 +71,9 @@ remote processes.
 # Import the ``dpf-core`` module and its examples files.
 
 import os
+
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
+from ansys.dpf.core import examples, operators as ops
 
 ###############################################################################
 # Configure the servers.

--- a/examples/07-distributed-post/02-distributed-msup_expansion.py
+++ b/examples/07-distributed-post/02-distributed-msup_expansion.py
@@ -94,10 +94,9 @@ chain that is used to compute the final result.
 # Import the ``dpf-core`` module and its examples files.
 
 import os
-from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
 
+from ansys.dpf import core as dpf
+from ansys.dpf.core import examples, operators as ops
 
 ###############################################################################
 # Configure the servers

--- a/examples/07-distributed-post/03-distributed-msup_expansion_steps.py
+++ b/examples/07-distributed-post/03-distributed-msup_expansion_steps.py
@@ -97,10 +97,9 @@ chain that is used to compute the final result.
 # Import the ``dpf-core`` module and its examples files.
 
 import os
-from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
 
+from ansys.dpf import core as dpf
+from ansys.dpf.core import examples, operators as ops
 
 ###############################################################################
 # Configure the servers

--- a/examples/07-distributed-post/06-distributed_stress_averaging.py
+++ b/examples/07-distributed-post/06-distributed_stress_averaging.py
@@ -36,9 +36,7 @@ After remote post-processing, results are merged on the local process.
 # Import dpf module and its examples files
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
-
+from ansys.dpf.core import examples, operators as ops
 
 ###############################################################################
 # Configure the servers

--- a/examples/08-python-operators/00-wrapping_numpy_capabilities.py
+++ b/examples/08-python-operators/00-wrapping_numpy_capabilities.py
@@ -56,9 +56,8 @@ be wrapped in Python plugins.
 #
 # Download and display the Python script.
 
-from ansys.dpf.core import examples
 from ansys.dpf import core as dpf
-
+from ansys.dpf.core import examples
 
 GITHUB_SOURCE_URL = (
     "https://github.com/ansys/pydpf-core/" "raw/examples/first_python_plugins/python_plugins"
@@ -85,6 +84,7 @@ with open(operator_file_path, "r") as f:
 #
 
 import os
+
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 

--- a/examples/08-python-operators/01-package_python_operators.py
+++ b/examples/08-python-operators/01-package_python_operators.py
@@ -57,9 +57,8 @@ For this example, the plug-in package contains two different operators:
 
 import os
 
-from ansys.dpf.core import examples
 from ansys.dpf import core as dpf
-
+from ansys.dpf.core import examples
 
 print("\033[1m average_filter_plugin")
 file_list = ["__init__.py", "operators.py", "operators_loader.py", "common.py"]

--- a/examples/08-python-operators/02-python_operators_with_dependencies.py
+++ b/examples/08-python-operators/02-python_operators_with_dependencies.py
@@ -59,9 +59,8 @@ file at the given path.
 
 import os
 
-from ansys.dpf.core import examples
 from ansys.dpf import core as dpf
-
+from ansys.dpf.core import examples
 
 print("\033[1m gltf_plugin")
 file_list = [

--- a/examples/09-averaging/01-average_across_bodies.py
+++ b/examples/09-averaging/01-average_across_bodies.py
@@ -46,9 +46,7 @@ of a postprocessing workflow can be different when averaging and when not.
 # Import the necessary modules
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import operators as ops
-from ansys.dpf.core import examples
-
+from ansys.dpf.core import examples, operators as ops
 
 ###############################################################################
 # Load the simulation results from an RST file and create a model of it.

--- a/examples/10-mesh_operations/05-skin_extraction.py
+++ b/examples/10-mesh_operations/05-skin_extraction.py
@@ -33,9 +33,7 @@ can be useful for specific results and for performance.
 
 # Import necessary modules
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
-
+from ansys.dpf.core import examples, operators as ops
 
 ###############################################################################
 # Create a model object to establish a connection with an

--- a/examples/10-mesh_operations/13-nodes_in_local_coordinate_system.py
+++ b/examples/10-mesh_operations/13-nodes_in_local_coordinate_system.py
@@ -43,7 +43,6 @@ The script below demonstrates the methodology using PyDPF.
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 
-
 ###############################################################################
 # Create a model object to establish a connection with an example result file:
 model = dpf.Model(examples.download_hemisphere())

--- a/examples/14-lsdyna/00-lsdyna_operators.py
+++ b/examples/14-lsdyna/00-lsdyna_operators.py
@@ -36,6 +36,7 @@ This example provides an overview of the LS-DYNA results providers.
 """
 
 import matplotlib.pyplot as plt
+
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ select = [
 #   "E",    # pycodestyle, see https://beta.ruff.rs/docs/rules/#pycodestyle-e-w
 #   "D",    # pydocstyle, see https://beta.ruff.rs/docs/rules/#pydocstyle-d
 #   "F",    # pyflakes, see https://beta.ruff.rs/docs/rules/#pyflakes-f
-#   "I",    # isort, see https://beta.ruff.rs/docs/rules/#isort-i
+    "I",    # isort, see https://beta.ruff.rs/docs/rules/#isort-i
 #   "N",    # pep8-naming, see https://beta.ruff.rs/docs/rules/#pep8-naming-n
 #   "PTH",  # flake9-use-pathlib, https://beta.ruff.rs/docs/rules/#flake8-use-pathlib-pth
 #   "TD",   # flake8-todos, https://docs.astral.sh/ruff/rules/#flake8-todos-td

--- a/src/ansys/dpf/core/_custom_operators_helpers.py
+++ b/src/ansys/dpf/core/_custom_operators_helpers.py
@@ -20,28 +20,28 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from ansys.dpf.gate import capi, external_operator_capi
 from enum import Enum
 
 from ansys.dpf.core import (
-    field,
-    property_field,
-    scoping,
     collection,
+    custom_type_field,
     data_sources,
-    meshed_region,
-    time_freq_support,
-    workflow,
     data_tree,
     dpf_operator,
+    field,
     fields_container,
-    scopings_container,
-    meshes_container,
-    result_info,
-    string_field,
-    custom_type_field,
     generic_data_container,
+    meshed_region,
+    meshes_container,
+    property_field,
+    result_info,
+    scoping,
+    scopings_container,
+    string_field,
+    time_freq_support,
+    workflow,
 )
+from ansys.dpf.gate import capi, external_operator_capi
 
 external_operator_api = external_operator_capi.ExternalOperatorCAPI
 

--- a/src/ansys/dpf/core/animation.py
+++ b/src/ansys/dpf/core/animation.py
@@ -20,8 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import ansys.dpf.core as dpf
 import numpy as np
+
+import ansys.dpf.core as dpf
 
 
 def animate_mode(

--- a/src/ansys/dpf/core/animator.py
+++ b/src/ansys/dpf/core/animator.py
@@ -28,8 +28,9 @@ This module contains the DPF animator class.
 Contains classes used to animate results based on workflows using PyVista.
 """
 
+from typing import Sequence, Union
+
 import numpy as np
-from typing import Union, Sequence
 
 import ansys.dpf.core as core
 from ansys.dpf.core.helpers.utils import _sort_supported_kwargs

--- a/src/ansys/dpf/core/any.py
+++ b/src/ansys/dpf/core/any.py
@@ -32,13 +32,11 @@ import warnings
 
 import numpy as np
 
-import ansys.dpf.core.server_types
-from ansys.dpf.core import server as server_module
-from ansys.dpf.core import errors
+from ansys.dpf.core import errors, server as server_module
 from ansys.dpf.core.check_version import server_meet_version, server_meet_version_and_raise
 from ansys.dpf.core.common import create_dpf_instance
-from ansys.dpf.gate import any_abstract_api, integral_types
-from ansys.dpf.gate import dpf_vector
+import ansys.dpf.core.server_types
+from ansys.dpf.gate import any_abstract_api, dpf_vector, integral_types
 
 
 class Any:
@@ -114,14 +112,14 @@ class Any:
 
     def _type_to_new_from_get_as_method(self, obj):
         from ansys.dpf.core import (
-            field,
-            property_field,
-            generic_data_container,
-            string_field,
-            scoping,
-            data_tree,
-            custom_type_field,
             collection,
+            custom_type_field,
+            data_tree,
+            field,
+            generic_data_container,
+            property_field,
+            scoping,
+            string_field,
         )
 
         if issubclass(obj, int):

--- a/src/ansys/dpf/core/available_result.py
+++ b/src/ansys/dpf/core/available_result.py
@@ -25,10 +25,11 @@ AvailableResult
 ===============
 """
 
+from enum import Enum, unique
 from typing import List
 from warnings import warn
-from ansys.dpf.core.common import _remove_spaces, _make_as_function_name, natures
-from enum import Enum, unique
+
+from ansys.dpf.core.common import _make_as_function_name, _remove_spaces, natures
 
 
 @unique

--- a/src/ansys/dpf/core/check_version.py
+++ b/src/ansys/dpf/core/check_version.py
@@ -26,10 +26,11 @@ Check the matching for a client/server pair.
 Used to verify if the server version is a minimum value.
 """
 
-from ansys.dpf.core import errors as dpf_errors
+from functools import wraps
 import sys
 import weakref
-from functools import wraps
+
+from ansys.dpf.core import errors as dpf_errors
 
 
 def server_meet_version(required_version, server):

--- a/src/ansys/dpf/core/collection.py
+++ b/src/ansys/dpf/core/collection.py
@@ -27,10 +27,11 @@ Collection
 """
 
 from __future__ import annotations
+
+from ansys.dpf.core import errors, server as server_module
 from ansys.dpf.core.any import Any
-from ansys.dpf.core.collection_base import CollectionBase, TYPE
+from ansys.dpf.core.collection_base import TYPE, CollectionBase
 from ansys.dpf.core.common import create_dpf_instance
-from ansys.dpf.core import server as server_module, errors
 
 
 class Collection(CollectionBase[TYPE]):

--- a/src/ansys/dpf/core/collection_base.py
+++ b/src/ansys/dpf/core/collection_base.py
@@ -28,26 +28,27 @@ Contains classes associated with the DPF collection.
 """
 
 from __future__ import annotations
+
 import abc
-import warnings
 import traceback
+from typing import TYPE_CHECKING, Generic, List, Optional, TypeVar
+import warnings
 
 import numpy as np
 
-from ansys.dpf.core.check_version import version_requires
-from ansys.dpf.core.server_types import BaseServer
-from ansys.dpf.core.scoping import Scoping
-from ansys.dpf.core.label_space import LabelSpace
 from ansys.dpf.core import server as server_module
+from ansys.dpf.core.check_version import version_requires
+from ansys.dpf.core.label_space import LabelSpace
+from ansys.dpf.core.scoping import Scoping
+from ansys.dpf.core.server_types import BaseServer
 from ansys.dpf.gate import (
     collection_capi,
     collection_grpcapi,
     data_processing_capi,
     data_processing_grpcapi,
-    dpf_vector,
     dpf_array,
+    dpf_vector,
 )
-from typing import List, Optional, Generic, TypeVar, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ansys.dpf.core.support import Support
@@ -466,9 +467,9 @@ class CollectionBase(Generic[TYPE]):
         """
         from ansys.dpf.core.time_freq_support import TimeFreqSupport
         from ansys.dpf.gate import (
+            object_handler,
             support_capi,
             support_grpcapi,
-            object_handler,
         )
 
         data_api = self._server.get_api_for_type(

--- a/src/ansys/dpf/core/common.py
+++ b/src/ansys/dpf/core/common.py
@@ -29,12 +29,12 @@ Common
 
 """
 
+from enum import Enum
 import re
 import sys
-from enum import Enum
 
 from ansys.dpf.core.misc import module_exists
-from ansys.dpf.gate.common import locations, ProgressBarBase  # noqa: F401
+from ansys.dpf.gate.common import ProgressBarBase, locations  # noqa: F401
 from ansys.dpf.gate.dpf_vector import (  # noqa: F401
     get_size_of_list as _get_size_of_list,
 )
@@ -127,27 +127,27 @@ class types(Enum):
 
 def types_enum_to_types():
     from ansys.dpf.core import (
+        Any,
+        collection,
+        custom_type_field,
         cyclic_support,
         data_sources,
+        data_tree,
+        dpf_operator,
         field,
         fields_container,
-        collection,
+        generic_data_container,
+        mesh_info,
         meshed_region,
         meshes_container,
         property_field,
-        string_field,
-        custom_type_field,
         result_info,
         scoping,
         scopings_container,
-        time_freq_support,
-        dpf_operator,
-        data_tree,
-        workflow,
         streams_container,
-        generic_data_container,
-        mesh_info,
-        Any,
+        string_field,
+        time_freq_support,
+        workflow,
     )
     from ansys.dpf.gate import dpf_vector
 
@@ -364,26 +364,26 @@ def type_to_internal_object_keyword():
     global _type_to_internal_object_keyword
     if _type_to_internal_object_keyword is None:
         from ansys.dpf.core import (
+            any,
+            collection,
+            custom_type_field,
             cyclic_support,
             data_sources,
+            data_tree,
+            dpf_operator,
             field,
             fields_container,
+            generic_data_container,
             meshed_region,
             meshes_container,
             property_field,
-            string_field,
-            custom_type_field,
             result_info,
             scoping,
             scopings_container,
-            time_freq_support,
-            dpf_operator,
-            data_tree,
-            workflow,
             streams_container,
-            generic_data_container,
-            any,
-            collection,
+            string_field,
+            time_freq_support,
+            workflow,
         )
 
         _type_to_internal_object_keyword = SubClassSmartDict(
@@ -419,8 +419,8 @@ _type_to_special_dpf_constructors = None
 def type_to_special_dpf_constructors():
     global _type_to_special_dpf_constructors
     if _type_to_special_dpf_constructors is None:
-        from ansys.dpf.gate.dpf_vector import DPFVectorInt
         from ansys.dpf.core import collection_base
+        from ansys.dpf.gate.dpf_vector import DPFVectorInt
 
         _type_to_special_dpf_constructors = {
             DPFVectorInt: lambda obj, server: collection_base.IntCollection(

--- a/src/ansys/dpf/core/config.py
+++ b/src/ansys/dpf/core/config.py
@@ -26,16 +26,16 @@ Operator Configuration
 """
 
 import functools
-import warnings
 import traceback
+import warnings
 
 from ansys.dpf.core import server as server_module
+from ansys.dpf.core.operator_specification import Specification
 from ansys.dpf.gate import (
+    operator_config_abstract_api,
     operator_config_capi,
     operator_config_grpcapi,
-    operator_config_abstract_api,
 )
-from ansys.dpf.core.operator_specification import Specification
 
 
 class Config:

--- a/src/ansys/dpf/core/core.py
+++ b/src/ansys/dpf/core/core.py
@@ -25,27 +25,26 @@ Core
 ====
 """
 
-import os
 import logging
+import os
 import warnings
 import weakref
 
-from ansys.dpf.core import errors, misc
-from ansys.dpf.core import server as server_module
-from ansys.dpf.core.check_version import version_requires, server_meet_version
+from ansys.dpf.core import errors, misc, server as server_module
+from ansys.dpf.core.check_version import server_meet_version, version_requires
 from ansys.dpf.core.runtime_config import (
     RuntimeClientConfig,
     RuntimeCoreConfig,
 )
 from ansys.dpf.gate import (
-    data_processing_capi,
-    data_processing_grpcapi,
-    tmp_dir_capi,
-    tmp_dir_grpcapi,
     collection_capi,
     collection_grpcapi,
+    data_processing_capi,
+    data_processing_grpcapi,
     integral_types,
     object_handler,
+    tmp_dir_capi,
+    tmp_dir_grpcapi,
 )
 
 try:
@@ -304,8 +303,8 @@ def _deep_copy(dpf_entity, server=None):
        deep_copy of dpf_entity: core.Operator, core.Workflow, core.Scoping,
                                 core.Field, core.FieldsContainer, core.MeshedRegion...
     """
+    from ansys.dpf.core.common import types, types_enum_to_types
     from ansys.dpf.core.operators.serialization import serializer_to_string, string_deserializer
-    from ansys.dpf.core.common import types_enum_to_types, types
 
     entity_server = dpf_entity._server if hasattr(dpf_entity, "_server") else None
     serializer = serializer_to_string(server=entity_server)

--- a/src/ansys/dpf/core/custom_fields_container.py
+++ b/src/ansys/dpf/core/custom_fields_container.py
@@ -29,8 +29,8 @@ These new classes offer helpers to access data for specific usage, such as
 results split by body or split by material.
 """
 
-from ansys.dpf.core.fields_container import FieldsContainer
 from ansys.dpf.core import elements
+from ansys.dpf.core.fields_container import FieldsContainer
 
 
 class ElShapeFieldsContainer(FieldsContainer):

--- a/src/ansys/dpf/core/custom_operator.py
+++ b/src/ansys/dpf/core/custom_operator.py
@@ -35,30 +35,30 @@ import pathlib
 import re
 import shutil
 import tempfile
+import traceback
 import warnings
 import zipfile
 
 import numpy
-import traceback
 
 from ansys.dpf import core as dpf
 from ansys.dpf.core import (
-    settings,
+    AvailableServerContexts,
+    collection,
+    dpf_operator,
+    operator_specification,
     server,
     server_factory,
-    operator_specification,
-    dpf_operator,
-    collection,
-    AvailableServerContexts,
+    settings,
 )
 from ansys.dpf.core._custom_operators_helpers import (
     __operator_main__,
-    functions_registry,
-    external_operator_api,
-    _type_to_output_method,
     _type_to_input_method,
+    _type_to_output_method,
+    external_operator_api,
+    functions_registry,
 )
-from ansys.dpf.gate import object_handler, capi, dpf_vector, integral_types
+from ansys.dpf.gate import capi, dpf_vector, integral_types, object_handler
 
 
 def update_virtual_environment_for_custom_operators(

--- a/src/ansys/dpf/core/custom_type_field.py
+++ b/src/ansys/dpf/core/custom_type_field.py
@@ -31,10 +31,8 @@ import warnings
 
 import numpy as np
 
-from ansys.dpf.core import server as server_module
-from ansys.dpf.core import errors
-from ansys.dpf.core import scoping
-from ansys.dpf.core.common import locations, _get_size_of_list
+from ansys.dpf.core import errors, scoping, server as server_module
+from ansys.dpf.core.common import _get_size_of_list, locations
 from ansys.dpf.core.field_base import _FieldBase
 from ansys.dpf.core.field_definition import FieldDefinition
 from ansys.dpf.core.support import Support

--- a/src/ansys/dpf/core/cyclic_support.py
+++ b/src/ansys/dpf/core/cyclic_support.py
@@ -28,10 +28,9 @@ Cyclic Support
 import traceback
 import warnings
 
-from ansys.dpf.gate import cyclic_support_capi, cyclic_support_grpcapi
-
 from ansys.dpf.core import server as server_module
 from ansys.dpf.core.scoping import Scoping
+from ansys.dpf.gate import cyclic_support_capi, cyclic_support_grpcapi
 
 
 class CyclicSupport:

--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -28,21 +28,19 @@ Data Sources
 """
 
 import os
-import warnings
 import traceback
 from typing import Union
+import warnings
 
-from ansys.dpf.core import server as server_module
+from ansys.dpf.core import errors, server as server_module
+from ansys.dpf.core.check_version import version_requires
 from ansys.dpf.gate import (
+    data_processing_capi,
+    data_processing_grpcapi,
     data_sources_capi,
     data_sources_grpcapi,
     integral_types,
-    data_processing_capi,
-    data_processing_grpcapi,
 )
-
-from ansys.dpf.core.check_version import version_requires
-from ansys.dpf.core import errors
 
 
 class DataSources:

--- a/src/ansys/dpf/core/data_tree.py
+++ b/src/ansys/dpf/core/data_tree.py
@@ -32,16 +32,14 @@ import traceback
 import warnings
 import weakref
 
+from ansys.dpf.core import collection_base, common, errors, server as server_module
 from ansys.dpf.core.mapping_types import types
-from ansys.dpf.core import server as server_module
-from ansys.dpf.core import collection_base
-from ansys.dpf.core import errors, common
 from ansys.dpf.gate import (
+    data_processing_capi,
+    data_processing_grpcapi,
     dpf_data_tree_abstract_api,
     dpf_data_tree_capi,
     dpf_data_tree_grpcapi,
-    data_processing_capi,
-    data_processing_grpcapi,
     integral_types,
 )
 

--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -27,37 +27,37 @@ Operator
 ========
 """
 
+from enum import Enum
 import logging
 import os
 import traceback
 import warnings
 
-from enum import Enum
+from ansys.dpf.core import server as server_module
 from ansys.dpf.core.check_version import (
-    version_requires,
     server_meet_version,
     server_meet_version_and_raise,
+    version_requires,
 )
+from ansys.dpf.core.common import types_enum_to_types
 from ansys.dpf.core.config import Config
 from ansys.dpf.core.errors import DpfVersionNotSupported
 from ansys.dpf.core.inputs import Inputs
 from ansys.dpf.core.mapping_types import types
-from ansys.dpf.core.common import types_enum_to_types
-from ansys.dpf.core.outputs import Output, Outputs, _Outputs
-from ansys.dpf.core import server as server_module
 from ansys.dpf.core.operator_specification import Specification
+from ansys.dpf.core.outputs import Output, Outputs, _Outputs
 from ansys.dpf.core.unit_system import UnitSystem
 from ansys.dpf.gate import (
-    operator_capi,
-    operator_abstract_api,
-    operator_grpcapi,
-    data_processing_capi,
-    data_processing_grpcapi,
     collection_capi,
     collection_grpcapi,
+    data_processing_capi,
+    data_processing_grpcapi,
     dpf_vector,
-    object_handler,
     integral_types,
+    object_handler,
+    operator_abstract_api,
+    operator_capi,
+    operator_grpcapi,
 )
 
 LOG = logging.getLogger(__name__)
@@ -348,27 +348,27 @@ class Operator:
     @property
     def _type_to_output_method(self):
         from ansys.dpf.core import (
+            any,
+            collection,
+            collection_base,
+            custom_type_field,
             cyclic_support,
             data_sources,
+            data_tree,
             field,
             fields_container,
+            generic_data_container,
+            mesh_info,
             meshed_region,
             meshes_container,
             property_field,
-            string_field,
-            custom_type_field,
             result_info,
             scoping,
             scopings_container,
-            time_freq_support,
-            data_tree,
-            workflow,
-            collection,
             streams_container,
-            generic_data_container,
-            mesh_info,
-            collection_base,
-            any,
+            string_field,
+            time_freq_support,
+            workflow,
         )
 
         out = [
@@ -480,22 +480,22 @@ class Operator:
     @property
     def _type_to_input_method(self):
         from ansys.dpf.core import (
+            any,
+            collection_base,
+            custom_type_field,
             cyclic_support,
             data_sources,
-            field,
-            collection_base,
-            meshed_region,
-            property_field,
-            string_field,
-            custom_type_field,
-            scoping,
-            time_freq_support,
             data_tree,
-            workflow,
-            model,
+            field,
             generic_data_container,
-            any,
+            meshed_region,
+            model,
+            property_field,
+            scoping,
             streams_container,
+            string_field,
+            time_freq_support,
+            workflow,
         )
 
         out = [

--- a/src/ansys/dpf/core/elements.py
+++ b/src/ansys/dpf/core/elements.py
@@ -28,13 +28,16 @@ Elements
 """
 
 from __future__ import annotations
+
 from enum import Enum
+
 import numpy as np
+
 from ansys.dpf.core import nodes
-from ansys.dpf.core.common import locations, elemental_properties
+from ansys.dpf.core.check_version import version_requires
+from ansys.dpf.core.common import elemental_properties, locations
 from ansys.dpf.core.element_descriptor import ElementDescriptor
 from ansys.dpf.gate import integral_types
-from ansys.dpf.core.check_version import version_requires
 
 
 class Element:

--- a/src/ansys/dpf/core/errors.py
+++ b/src/ansys/dpf/core/errors.py
@@ -34,6 +34,7 @@ Errors
 """
 
 from functools import wraps
+
 from ansys.dpf.gate.errors import (  # noqa: F401
     DPFServerException,
     DPFServerNullObject,

--- a/src/ansys/dpf/core/examples/__init__.py
+++ b/src/ansys/dpf/core/examples/__init__.py
@@ -20,8 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .examples import *
 from .downloads import *
+from .examples import *
 
 
 # called if module.<name> fails

--- a/src/ansys/dpf/core/examples/downloads.py
+++ b/src/ansys/dpf/core/examples/downloads.py
@@ -28,6 +28,7 @@ Download example datasets from https://github.com/ansys/example-data"""
 import os
 import urllib.request
 import warnings
+
 from ansys.dpf.core.examples.examples import find_files
 
 EXAMPLE_REPO = "https://github.com/ansys/example-data/raw/master/"

--- a/src/ansys/dpf/core/examples/examples.py
+++ b/src/ansys/dpf/core/examples/examples.py
@@ -30,10 +30,8 @@ Examples result files.
 
 import os
 
-from ansys.dpf.core import server as server_module
+from ansys.dpf.core import DataSources, path_utilities, server as server_module
 from ansys.dpf.core.core import upload_file_in_tmp_folder
-from ansys.dpf.core import path_utilities
-from ansys.dpf.core import DataSources
 
 
 def get_example_required_minimum_dpf_version(file: os.PathLike) -> str:

--- a/src/ansys/dpf/core/faces.py
+++ b/src/ansys/dpf/core/faces.py
@@ -28,10 +28,11 @@ Faces
 """
 
 import numpy as np
+
 from ansys.dpf.core import scoping
+from ansys.dpf.core.check_version import version_requires
 from ansys.dpf.core.common import face_properties
 from ansys.dpf.core.elements import element_types
-from ansys.dpf.core.check_version import version_requires
 
 
 @version_requires("7.0")

--- a/src/ansys/dpf/core/field.py
+++ b/src/ansys/dpf/core/field.py
@@ -28,18 +28,18 @@ Field
 """
 
 import numpy as np
+
 from ansys import dpf
-from ansys.dpf.core import errors, meshed_region, time_freq_support, scoping
-from ansys.dpf.core import dimensionality
-from ansys.dpf.core.common import locations, natures, types, _get_size_of_list
+from ansys.dpf.core import dimensionality, errors, meshed_region, scoping, time_freq_support
+from ansys.dpf.core.common import _get_size_of_list, locations, natures, types
 from ansys.dpf.core.field_base import _FieldBase, _LocalFieldBase
 from ansys.dpf.core.field_definition import FieldDefinition
 from ansys.dpf.gate import (
+    dpf_array,
+    dpf_vector,
     field_abstract_api,
     field_capi,
     field_grpcapi,
-    dpf_array,
-    dpf_vector,
 )
 
 

--- a/src/ansys/dpf/core/field_base.py
+++ b/src/ansys/dpf/core/field_base.py
@@ -20,23 +20,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from abc import abstractmethod
 import traceback
 import warnings
 
-from abc import abstractmethod
-from ansys.dpf.gate.generated import field_abstract_api
+import numpy as np
 
-from ansys.dpf.core import scoping
-from ansys.dpf.core.common import natures, locations
-from ansys.dpf.core import errors
-from ansys.dpf.core import server as server_module
+from ansys.dpf.core import errors, scoping, server as server_module
 from ansys.dpf.core.cache import _setter
+from ansys.dpf.core.common import locations, natures
 from ansys.dpf.gate import (
     data_processing_capi,
     data_processing_grpcapi,
 )
-
-import numpy as np
+from ansys.dpf.gate.generated import field_abstract_api
 
 
 class _FieldBase:

--- a/src/ansys/dpf/core/field_definition.py
+++ b/src/ansys/dpf/core/field_definition.py
@@ -28,10 +28,10 @@ FieldDefinition
 import traceback
 import warnings
 
-from ansys.dpf.core.common import natures, shell_layers
-from ansys.dpf.core.check_version import version_requires
-from ansys.dpf.core.dimensionality import Dimensionality
 from ansys.dpf.core import server as server_module
+from ansys.dpf.core.check_version import version_requires
+from ansys.dpf.core.common import natures, shell_layers
+from ansys.dpf.core.dimensionality import Dimensionality
 from ansys.dpf.gate import (
     field_definition_capi,
     field_definition_grpcapi,

--- a/src/ansys/dpf/core/fields_container.py
+++ b/src/ansys/dpf/core/fields_container.py
@@ -29,9 +29,8 @@ Contains classes associated with the DPF FieldsContainer.
 """
 
 from ansys import dpf
+from ansys.dpf.core import errors as dpf_errors, field
 from ansys.dpf.core.collection_base import CollectionBase
-from ansys.dpf.core import errors as dpf_errors
-from ansys.dpf.core import field
 
 
 class FieldsContainer(CollectionBase[field.Field]):
@@ -645,8 +644,7 @@ class FieldsContainer(CollectionBase[field.Field]):
         -------
         add : operators.math.add_fc
         """
-        from ansys.dpf.core import dpf_operator
-        from ansys.dpf.core import operators
+        from ansys.dpf.core import dpf_operator, operators
 
         if hasattr(operators, "math") and hasattr(operators.math, "add_fc"):
             op = operators.math.add_fc(self, fields_b, server=self._server)
@@ -663,8 +661,7 @@ class FieldsContainer(CollectionBase[field.Field]):
         -------
         minus : operators.math.minus_fc
         """
-        from ansys.dpf.core import dpf_operator
-        from ansys.dpf.core import operators
+        from ansys.dpf.core import dpf_operator, operators
 
         if hasattr(operators, "math") and hasattr(operators.math, "minus_fc"):
             op = operators.math.minus_fc(server=self._server)
@@ -677,8 +674,7 @@ class FieldsContainer(CollectionBase[field.Field]):
     def __pow__(self, value):
         if value != 2:
             raise ValueError('DPF only the value is "2" supported')
-        from ansys.dpf.core import dpf_operator
-        from ansys.dpf.core import operators
+        from ansys.dpf.core import dpf_operator, operators
 
         if hasattr(operators, "math") and hasattr(operators.math, "sqr_fc"):
             op = operators.math.sqr_fc(server=self._server)
@@ -695,8 +691,7 @@ class FieldsContainer(CollectionBase[field.Field]):
         -------
         mul : operators.math.generalized_inner_product_fc
         """
-        from ansys.dpf.core import dpf_operator
-        from ansys.dpf.core import operators
+        from ansys.dpf.core import dpf_operator, operators
 
         if hasattr(operators, "math") and hasattr(operators.math, "generalized_inner_product_fc"):
             op = operators.math.generalized_inner_product_fc(server=self._server)

--- a/src/ansys/dpf/core/fields_container_factory.py
+++ b/src/ansys/dpf/core/fields_container_factory.py
@@ -27,9 +27,7 @@ fields_container_factory
 Contains functions to simplify creating a fields container.
 """
 
-from ansys.dpf.core import FieldsContainer, TimeFreqSupport
-from ansys.dpf.core import errors as dpf_errors
-from ansys.dpf.core import fields_factory
+from ansys.dpf.core import FieldsContainer, TimeFreqSupport, errors as dpf_errors, fields_factory
 from ansys.dpf.core.common import locations
 
 

--- a/src/ansys/dpf/core/fields_factory.py
+++ b/src/ansys/dpf/core/fields_factory.py
@@ -27,12 +27,11 @@ fields_factory
 Contains functions to simplify creating fields.
 """
 
-from ansys.dpf.core.common import natures, locations
-from ansys.dpf.core import Field
-from ansys.dpf.core import server as server_module
-from ansys.dpf.gate import field_capi, field_grpcapi
-
 import numpy as np
+
+from ansys.dpf.core import Field, server as server_module
+from ansys.dpf.core.common import locations, natures
+from ansys.dpf.gate import field_capi, field_grpcapi
 
 
 def field_from_array(arr, server=None):

--- a/src/ansys/dpf/core/generic_data_container.py
+++ b/src/ansys/dpf/core/generic_data_container.py
@@ -28,10 +28,11 @@ GenericDataContainer
 """
 
 from __future__ import annotations
-import traceback
-import warnings
+
 import builtins
-from typing import Union, TYPE_CHECKING
+import traceback
+from typing import TYPE_CHECKING, Union
+import warnings
 
 import numpy as np
 
@@ -39,15 +40,11 @@ from ansys.dpf.core.check_version import server_meet_version
 from ansys.dpf.gate import dpf_vector
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ansys.dpf.core import Field, Scoping, StringField, GenericDataContainer
+    from ansys.dpf.core import Field, GenericDataContainer, Scoping, StringField
 
-from ansys.dpf.core.dpf_operator import _write_output_type_to_type
-
-
-from ansys.dpf.core import server as server_module
-from ansys.dpf.core import errors, types
+from ansys.dpf.core import collection_base, errors, server as server_module, types
 from ansys.dpf.core.any import Any
-from ansys.dpf.core import collection_base
+from ansys.dpf.core.dpf_operator import _write_output_type_to_type
 from ansys.dpf.core.mapping_types import map_types_to_python
 
 

--- a/src/ansys/dpf/core/generic_support.py
+++ b/src/ansys/dpf/core/generic_support.py
@@ -27,9 +27,9 @@ GenericSupport
 ==============
 """
 
-from ansys.dpf.gate import generic_support_capi, generic_support_grpcapi
+from ansys.dpf.core import errors, field, property_field, string_field
 from ansys.dpf.core.support import Support
-from ansys.dpf.core import field, property_field, string_field, errors
+from ansys.dpf.gate import generic_support_capi, generic_support_grpcapi
 
 
 class GenericSupport(Support):

--- a/src/ansys/dpf/core/geometry.py
+++ b/src/ansys/dpf/core/geometry.py
@@ -22,13 +22,12 @@
 
 """Module containing the different geometry objects."""
 
-from ansys.dpf import core as dpf
+import numpy as np
 
+from ansys.dpf import core as dpf
 from ansys.dpf.core import Field
 from ansys.dpf.core.fields_factory import field_from_array
 from ansys.dpf.core.plotter import DpfPlotter
-
-import numpy as np
 
 
 def normalize_vector(vector):

--- a/src/ansys/dpf/core/geometry_factory.py
+++ b/src/ansys/dpf/core/geometry_factory.py
@@ -25,12 +25,12 @@
 import numpy as np
 
 from ansys.dpf.core.geometry import (
-    Points,
     Line,
     Plane,
-    normalize_vector,
-    get_plane_local_axis,
+    Points,
     get_local_coords_from_global,
+    get_plane_local_axis,
+    normalize_vector,
 )
 
 

--- a/src/ansys/dpf/core/helpers/streamlines.py
+++ b/src/ansys/dpf/core/helpers/streamlines.py
@@ -22,8 +22,9 @@
 
 """Streamlines computation specific helpers."""
 
-import numpy as np
 import warnings
+
+import numpy as np
 
 from ansys.dpf.core.common import locations
 from ansys.dpf.core.fields_container import FieldsContainer

--- a/src/ansys/dpf/core/incremental.py
+++ b/src/ansys/dpf/core/incremental.py
@@ -27,9 +27,9 @@ Incremental
 ===========
 """
 
-from ansys.dpf import core
+from typing import Any, Dict
 
-from typing import Dict, Any
+from ansys.dpf import core
 
 
 class IncrementalHelper:

--- a/src/ansys/dpf/core/inputs.py
+++ b/src/ansys/dpf/core/inputs.py
@@ -27,11 +27,12 @@ Inputs
 ======
 """
 
-import weakref
 from textwrap import wrap
-from ansys.dpf.core.mapping_types import map_types_to_python
-from ansys.dpf.core.outputs import _Outputs, Output
+import weakref
+
 from ansys.dpf import core
+from ansys.dpf.core.mapping_types import map_types_to_python
+from ansys.dpf.core.outputs import Output, _Outputs
 
 
 class Input:

--- a/src/ansys/dpf/core/label_space.py
+++ b/src/ansys/dpf/core/label_space.py
@@ -24,16 +24,17 @@
 Internal Usage
 """
 
-import warnings
 import traceback
 from typing import Dict
+import warnings
+
+from ansys.dpf.core import server as server_module
 from ansys.dpf.gate import (
-    label_space_capi,
-    label_space_grpcapi,
     data_processing_capi,
     data_processing_grpcapi,
+    label_space_capi,
+    label_space_grpcapi,
 )
-from ansys.dpf.core import server as server_module
 
 
 class LabelSpace:

--- a/src/ansys/dpf/core/mapping_types.py
+++ b/src/ansys/dpf/core/mapping_types.py
@@ -20,23 +20,23 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import sys
 import inspect
+import sys
 
-## to do : change that one the module is done
-from ansys.dpf.core.meshed_region import *  # noqa: F401, F403
 from ansys.dpf.core.available_result import *  # noqa: F401, F403
+from ansys.dpf.core.common import (
+    _camel_to_snake_case,
+    _smart_dict_camel,
+    _snake_to_camel_case,
+)
 from ansys.dpf.core.data_sources import *  # noqa: F401, F403
 from ansys.dpf.core.field import *  # noqa: F401, F403
 from ansys.dpf.core.fields_container import *  # noqa: F401, F403
+
+## to do : change that one the module is done
+from ansys.dpf.core.meshed_region import *  # noqa: F401, F403
 from ansys.dpf.core.scoping import *  # noqa: F401, F403
 from ansys.dpf.core.time_freq_support import *  # noqa: F401, F403
-from ansys.dpf.core.common import (
-    _smart_dict_camel,
-    _camel_to_snake_case,
-    _snake_to_camel_case,
-)
-
 
 map_types_to_cpp = _smart_dict_camel()
 for classes in inspect.getmembers(sys.modules[__name__], inspect.isclass):

--- a/src/ansys/dpf/core/meshed_region.py
+++ b/src/ansys/dpf/core/meshed_region.py
@@ -28,21 +28,19 @@ MeshedRegion
 import traceback
 import warnings
 
-import ansys.dpf.core.errors
-
-from ansys.dpf.core import scoping, field, property_field
+from ansys.dpf.core import field, property_field, scoping, server as server_module
+from ansys.dpf.core.cache import class_handling_cache
 from ansys.dpf.core.check_version import server_meet_version, version_requires
 from ansys.dpf.core.common import (
     locations,
-    types,
     nodal_properties,
+    types,
 )
 from ansys.dpf.core.elements import Elements, element_types
-from ansys.dpf.core.nodes import Nodes
+import ansys.dpf.core.errors
 from ansys.dpf.core.faces import Faces
+from ansys.dpf.core.nodes import Nodes
 from ansys.dpf.core.plotter import DpfPlotter, Plotter
-from ansys.dpf.core.cache import class_handling_cache
-from ansys.dpf.core import server as server_module
 from ansys.dpf.gate import meshed_region_capi, meshed_region_grpcapi
 
 

--- a/src/ansys/dpf/core/meshes_container.py
+++ b/src/ansys/dpf/core/meshes_container.py
@@ -27,10 +27,9 @@ MeshesContainer
 Contains classes associated with the DPF MeshesContainer.
 """
 
-from ansys.dpf.core import meshed_region
+from ansys.dpf.core import errors as dpf_errors, meshed_region
 from ansys.dpf.core.collection_base import CollectionBase
 from ansys.dpf.core.plotter import DpfPlotter
-from ansys.dpf.core import errors as dpf_errors
 
 
 class MeshesContainer(CollectionBase[meshed_region.MeshedRegion]):

--- a/src/ansys/dpf/core/misc.py
+++ b/src/ansys/dpf/core/misc.py
@@ -22,15 +22,15 @@
 
 """Miscellaneous functions for the DPF module."""
 
-import platform
 import glob
 import os
+from pkgutil import iter_modules
+import platform
 import re
 
-from pkgutil import iter_modules
 from ansys.dpf.core import errors
-from ansys.dpf.gate._version import __ansys_version__
 from ansys.dpf.gate import load_api
+from ansys.dpf.gate._version import __ansys_version__
 
 DEFAULT_FILE_CHUNK_SIZE = 524288
 DYNAMIC_RESULTS = True

--- a/src/ansys/dpf/core/model.py
+++ b/src/ansys/dpf/core/model.py
@@ -31,15 +31,14 @@ Module contains the Model class to manage file result models.
 """
 
 from ansys import dpf
-from ansys.dpf.core import Operator
-from ansys.dpf.core.common import types
-from ansys.dpf.core.data_sources import DataSources
-from ansys.dpf.core.results import Results, CommonResults
-from ansys.dpf.core.server_types import LOG
-from ansys.dpf.core import misc
-from ansys.dpf.core.errors import protect_source_op_not_found
+from ansys.dpf.core import Operator, misc
 from ansys.dpf.core._model_helpers import DataSourcesOrStreamsConnector
 from ansys.dpf.core.check_version import version_requires
+from ansys.dpf.core.common import types
+from ansys.dpf.core.data_sources import DataSources
+from ansys.dpf.core.errors import protect_source_op_not_found
+from ansys.dpf.core.results import CommonResults, Results
+from ansys.dpf.core.server_types import LOG
 
 
 class Model:

--- a/src/ansys/dpf/core/nodes.py
+++ b/src/ansys/dpf/core/nodes.py
@@ -28,9 +28,9 @@ Nodes
 """
 
 import numpy as np
-from ansys.dpf.core.common import nodal_properties, locations
+
 from ansys.dpf.core.check_version import version_requires
-from ansys.dpf.core.check_version import version_requires
+from ansys.dpf.core.common import locations, nodal_properties
 
 
 class Node:

--- a/src/ansys/dpf/core/operator_specification.py
+++ b/src/ansys/dpf/core/operator_specification.py
@@ -29,17 +29,17 @@ The OperatorSpecification Provides a documentation for each Operator
 """
 
 from __future__ import annotations
+
 import abc
 from typing import Union
-from ansys.dpf.core import server as server_module
+
+from ansys.dpf.core import common, mapping_types, server as server_module
+from ansys.dpf.core.check_version import server_meet_version, version_requires
 from ansys.dpf.gate import (
+    integral_types,
     operator_specification_capi,
     operator_specification_grpcapi,
-    integral_types,
 )
-from ansys.dpf.core import mapping_types, common
-from ansys.dpf.core.check_version import version_requires
-from ansys.dpf.core.check_version import server_meet_version
 
 
 class PinSpecification:

--- a/src/ansys/dpf/core/outputs.py
+++ b/src/ansys/dpf/core/outputs.py
@@ -27,10 +27,11 @@ Outputs
 =======
 """
 
-from ansys.dpf.core.mapping_types import map_types_to_python
-from ansys.dpf.core.common import types
-from ansys.dpf.core.operator_specification import PinSpecification
 import re
+
+from ansys.dpf.core.common import types
+from ansys.dpf.core.mapping_types import map_types_to_python
+from ansys.dpf.core.operator_specification import PinSpecification
 
 
 class Output:

--- a/src/ansys/dpf/core/path_utilities.py
+++ b/src/ansys/dpf/core/path_utilities.py
@@ -28,10 +28,10 @@ server into account to create path.
 """
 
 import os
-
-import ansys.dpf.core.server_types
-from ansys.dpf.core import server as server_module
 from pathlib import Path
+
+from ansys.dpf.core import server as server_module
+import ansys.dpf.core.server_types
 
 
 def join(*args, **kwargs):

--- a/src/ansys/dpf/core/plotter.py
+++ b/src/ansys/dpf/core/plotter.py
@@ -30,19 +30,19 @@ Contains classes used to plot a mesh and a fields container using PyVista.
 
 from __future__ import annotations
 
-import tempfile
 import os
 import sys
-import numpy as np
-import warnings
+import tempfile
 from typing import TYPE_CHECKING, List, Union
+import warnings
+
+import numpy as np
 
 from ansys import dpf
 from ansys.dpf import core
-from ansys.dpf.core.common import locations, DefinitionLabels
-from ansys.dpf.core.common import shell_layers as eshell_layers
-from ansys.dpf.core.helpers.streamlines import _sort_supported_kwargs
 from ansys.dpf.core import errors as dpf_errors
+from ansys.dpf.core.common import DefinitionLabels, locations, shell_layers as eshell_layers
+from ansys.dpf.core.helpers.streamlines import _sort_supported_kwargs
 from ansys.dpf.core.nodes import Node, Nodes
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -186,10 +186,9 @@ class _PyVistaPlotter:
 
         # Filter kwargs
         kwargs_in = _sort_supported_kwargs(bound_method=self._plotter.add_point_labels, **kwargs)
-        import pyvista as pv
-
         # The scalar data used will be the one of the last field added.
         from packaging.version import parse
+        import pyvista as pv
 
         active_scalars = None
         if parse(pv.__version__) >= parse("0.35.2"):

--- a/src/ansys/dpf/core/property_field.py
+++ b/src/ansys/dpf/core/property_field.py
@@ -26,18 +26,18 @@ PropertyField
 """
 
 import numpy as np
-from ansys.dpf.core.check_version import version_requires
-from ansys.dpf.core.common import natures, locations, _get_size_of_list
-from ansys.dpf.core import scoping, dimensionality
+
+from ansys.dpf.core import dimensionality, scoping
+from ansys.dpf.core.check_version import meets_version, version_requires
+from ansys.dpf.core.common import _get_size_of_list, locations, natures
 from ansys.dpf.core.field_base import _FieldBase, _LocalFieldBase
-from ansys.dpf.core.check_version import meets_version
 from ansys.dpf.core.field_definition import FieldDefinition
 from ansys.dpf.gate import (
+    dpf_array,
+    dpf_vector,
     property_field_abstract_api,
     property_field_capi,
     property_field_grpcapi,
-    dpf_array,
-    dpf_vector,
 )
 
 

--- a/src/ansys/dpf/core/result_info.py
+++ b/src/ansys/dpf/core/result_info.py
@@ -25,32 +25,29 @@ ResultInfo
 ==========
 """
 
+from enum import Enum, unique
 import traceback
+from types import SimpleNamespace
+from typing import List, Union
 import warnings
 
-from typing import List, Union
-from enum import Enum, unique
-from types import SimpleNamespace
+from ansys.dpf.core import available_result, collection_base, server as server_module, support
+from ansys.dpf.core.available_result import Homogeneity
+from ansys.dpf.core.check_version import version_requires
+from ansys.dpf.core.common import locations
+from ansys.dpf.core.cyclic_support import CyclicSupport
+from ansys.dpf.core.dimensionality import natures
+from ansys.dpf.core.label_space import LabelSpace
 from ansys.dpf.gate import (
-    result_info_capi,
-    result_info_grpcapi,
+    data_processing_capi,
+    data_processing_grpcapi,
     integral_types,
     label_space_capi,
     label_space_grpcapi,
     object_handler,
-    data_processing_grpcapi,
-    data_processing_capi,
+    result_info_capi,
+    result_info_grpcapi,
 )
-
-from ansys.dpf.core import collection_base
-from ansys.dpf.core import server as server_module
-from ansys.dpf.core import available_result, support
-from ansys.dpf.core.cyclic_support import CyclicSupport
-from ansys.dpf.core.label_space import LabelSpace
-from ansys.dpf.core.check_version import version_requires
-from ansys.dpf.core.dimensionality import natures
-from ansys.dpf.core.common import locations
-from ansys.dpf.core.available_result import Homogeneity
 
 
 @unique

--- a/src/ansys/dpf/core/results.py
+++ b/src/ansys/dpf/core/results.py
@@ -30,13 +30,12 @@ to easily access results in result files."""
 
 import functools
 
-from ansys.dpf.core import Operator
-from ansys.dpf.core import errors
-from ansys.dpf.core.scoping import Scoping
+from ansys.dpf.core import Operator, errors
 from ansys.dpf.core.custom_fields_container import (
-    ElShapeFieldsContainer,
     BodyFieldsContainer,
+    ElShapeFieldsContainer,
 )
+from ansys.dpf.core.scoping import Scoping
 
 
 class Results:

--- a/src/ansys/dpf/core/runtime_config.py
+++ b/src/ansys/dpf/core/runtime_config.py
@@ -25,9 +25,9 @@ RuntimeConfig
 =============
 """
 
-from ansys.dpf.core.data_tree import DataTree
-from ansys.dpf.core.common import types
 from ansys.dpf.core import misc
+from ansys.dpf.core.common import types
+from ansys.dpf.core.data_tree import DataTree
 
 
 class _RuntimeConfig:

--- a/src/ansys/dpf/core/scoping.py
+++ b/src/ansys/dpf/core/scoping.py
@@ -27,26 +27,25 @@ Scoping
 =======
 """
 
+import ctypes
 import traceback
 import warnings
-import ctypes
 
 import numpy as np
 
+from ansys.dpf.core import server as server_module, server_types
+from ansys.dpf.core.cache import _setter
 from ansys.dpf.core.check_version import version_requires
 from ansys.dpf.core.common import locations
-from ansys.dpf.core import server as server_module
-from ansys.dpf.core import server_types
-from ansys.dpf.core.cache import _setter
 from ansys.dpf.gate import (
-    scoping_capi,
-    scoping_grpcapi,
     data_processing_capi,
     data_processing_grpcapi,
-    dpf_vector_capi,
-    dpf_vector_abstract_api,
-    dpf_vector,
     dpf_array,
+    dpf_vector,
+    dpf_vector_abstract_api,
+    dpf_vector_capi,
+    scoping_capi,
+    scoping_grpcapi,
     utils,
 )
 

--- a/src/ansys/dpf/core/server.py
+++ b/src/ansys/dpf/core/server.py
@@ -26,30 +26,27 @@ Server
 Contains the directives necessary to start the DPF server.
 """
 
+import copy
 import functools
+import inspect
 import os
+import platform
 import socket
 import sys
-import weakref
-import copy
-import platform
-import inspect
-import warnings
 import traceback
 from typing import Union
+import warnings
+import weakref
 
 from ansys import dpf
-
-from ansys.dpf.core.misc import is_ubuntu, get_ansys_path
-from ansys.dpf.core import errors
-
+from ansys.dpf.core import errors, server_context
+from ansys.dpf.core.misc import get_ansys_path, is_ubuntu
 from ansys.dpf.core.server_factory import (
+    CommunicationProtocols,
     ServerConfig,
     ServerFactory,
-    CommunicationProtocols,
 )
 from ansys.dpf.core.server_types import DPF_DEFAULT_PORT, LOCALHOST, RUNNING_DOCKER, BaseServer
-from ansys.dpf.core import server_context
 
 
 def shutdown_global_server():

--- a/src/ansys/dpf/core/server_context.py
+++ b/src/ansys/dpf/core/server_context.py
@@ -36,11 +36,11 @@ variable.
 ANSYS_DPF_SERVER_CONTEXT=ENTRY and ANSYS_DPF_SERVER_CONTEXT=PREMIUM can be used.
 """
 
+from enum import Enum
 import os
 import warnings
-from enum import Enum
-from ansys.dpf.core import dpf_operator
-from ansys.dpf.core import errors
+
+from ansys.dpf.core import dpf_operator, errors
 
 
 class LicensingContextType(Enum):

--- a/src/ansys/dpf/core/server_factory.py
+++ b/src/ansys/dpf/core/server_factory.py
@@ -28,15 +28,15 @@ Contains the server factory as well as the communication
 protocols and server configurations available.
 """
 
+import io
 import logging
 import os
 import subprocess
 import time
-import io
 
 from ansys.dpf.gate.load_api import (
-    _get_path_in_install,
     _find_outdated_ansys_version,
+    _get_path_in_install,
 )
 
 
@@ -609,9 +609,9 @@ class ServerFactory:
         docker_config: DockerConfig = None,
     ):
         from ansys.dpf.core.server_types import (
-            LegacyGrpcServer,
             GrpcServer,
             InProcessServer,
+            LegacyGrpcServer,
         )
 
         # dpf.core.SERVER_CONFIGURATION is required to know what type of connection to set

--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -28,28 +28,28 @@ servers available for the factory.
 """
 
 from __future__ import annotations
+
 import abc
+from abc import ABC
+import ctypes
 import io
 import os
 import socket
 import subprocess
 import sys
+from threading import Lock, Thread
 import time
-import warnings
 import traceback
-from threading import Thread, Lock
-from abc import ABC
-import ctypes
 from typing import TYPE_CHECKING, Union
+import warnings
 
 import psutil
 
 import ansys.dpf.core as core
-from ansys.dpf.core.check_version import server_meet_version
-from ansys.dpf.core import errors, server_factory, __version__
+from ansys.dpf.core import __version__, errors, server_context, server_factory
 from ansys.dpf.core._version import min_server_version, server_to_ansys_version
-from ansys.dpf.core import server_context
-from ansys.dpf.gate import load_api, data_processing_grpcapi
+from ansys.dpf.core.check_version import server_meet_version
+from ansys.dpf.gate import data_processing_grpcapi, load_api
 
 if TYPE_CHECKING:
     from ansys.dpf.core.server_factory import DockerConfig
@@ -326,6 +326,7 @@ def launch_remote_dpf(version=None):
 def _compare_ansys_grpc_dpf_version(right_grpc_module_version_str: str, grpc_module_version: str):
     if right_grpc_module_version_str:
         import re
+
         from packaging.version import parse as parse_version
 
         right_version_first_numbers = re.search(r"\d", right_grpc_module_version_str)

--- a/src/ansys/dpf/core/session.py
+++ b/src/ansys/dpf/core/session.py
@@ -33,17 +33,13 @@ import traceback
 import warnings
 import weakref
 
-from ansys.dpf.gate import session_capi, session_grpcapi, capi
-
-from ansys.dpf.core import server as server_module
-from ansys.dpf.core import server_types, errors
-from ansys.dpf.core.check_version import version_requires, server_meet_version
+from ansys.dpf.core import data_tree, errors, server as server_module, server_types
+from ansys.dpf.core.check_version import server_meet_version, version_requires
 from ansys.dpf.core.common import (
     _common_percentage_progress_bar,
     _progress_bar_is_available,
 )
-from ansys.dpf.core import data_tree
-
+from ansys.dpf.gate import capi, session_capi, session_grpcapi
 
 LOG = logging.getLogger(__name__)
 LOG.setLevel("DEBUG")

--- a/src/ansys/dpf/core/settings.py
+++ b/src/ansys/dpf/core/settings.py
@@ -26,12 +26,11 @@ settings
 Customize the behavior of the module.
 """
 
+from ansys.dpf.core import core, misc
 from ansys.dpf.core.misc import module_exists
-from ansys.dpf.core import misc
 from ansys.dpf.core.server import set_server_configuration  # noqa: F401
 from ansys.dpf.core.server_context import set_default_server_context  # noqa: F401
 from ansys.dpf.core.server_factory import ServerConfig  # noqa: F401
-from ansys.dpf.core import core
 from ansys.dpf.gate import (
     data_processing_capi,
     data_processing_grpcapi,
@@ -115,9 +114,9 @@ def set_dynamic_available_results_capability(value) -> None:
 
 
 def _forward_to_gate():
-    from ansys.dpf.gate import settings
-    from ansys.dpf.core.misc import DEFAULT_FILE_CHUNK_SIZE
     from ansys.dpf.core.common import _common_progress_bar, _progress_bar_is_available
+    from ansys.dpf.core.misc import DEFAULT_FILE_CHUNK_SIZE
+    from ansys.dpf.gate import settings
 
     settings.forward_settings(
         DEFAULT_FILE_CHUNK_SIZE,
@@ -147,8 +146,8 @@ def get_runtime_client_config(server=None):
         with Ans.Dpf.GrpcClient configuration.
 
     """
-    from ansys.dpf.core.runtime_config import RuntimeClientConfig
     from ansys.dpf import core as root
+    from ansys.dpf.core.runtime_config import RuntimeClientConfig
 
     if server is None:
         server = root.SERVER

--- a/src/ansys/dpf/core/streams_container.py
+++ b/src/ansys/dpf/core/streams_container.py
@@ -27,17 +27,16 @@ StreamsContainer
 Contains classes associated with the DPF StreamsContainer.
 """
 
-import warnings
 import traceback
+import warnings
 
+from ansys.dpf.core import errors, server as server_module
 from ansys.dpf.core.server_types import BaseServer
-from ansys.dpf.core import server as server_module
 from ansys.dpf.gate import (
-    streams_capi,
     data_processing_capi,
     data_processing_grpcapi,
+    streams_capi,
 )
-from ansys.dpf.core import errors
 
 
 class StreamsContainer:

--- a/src/ansys/dpf/core/string_field.py
+++ b/src/ansys/dpf/core/string_field.py
@@ -25,20 +25,20 @@ StringField
 ===========
 """
 
+from typing import List
+
 import numpy as np
-from ansys.dpf.core.common import natures, locations, _get_size_of_list
-from ansys.dpf.core import scoping
-from ansys.dpf.core import server as server_module
-from ansys.dpf.core import errors
+
+from ansys.dpf.core import errors, scoping, server as server_module
+from ansys.dpf.core.common import _get_size_of_list, locations, natures
 from ansys.dpf.core.field_base import _FieldBase
 from ansys.dpf.gate import (
+    dpf_vector,
+    integral_types,
     string_field_abstract_api,
     string_field_capi,
     string_field_grpcapi,
-    dpf_vector,
-    integral_types,
 )
-from typing import List
 
 
 class StringField(_FieldBase):

--- a/src/ansys/dpf/core/support.py
+++ b/src/ansys/dpf/core/support.py
@@ -29,11 +29,10 @@ Support
 
 import traceback
 import warnings
-from ansys.dpf.gate import support_capi, support_grpcapi
-from ansys.dpf.core.check_version import version_requires
 
-from ansys.dpf.core import server as server_module
-from ansys.dpf.core import collection_base
+from ansys.dpf.core import collection_base, server as server_module
+from ansys.dpf.core.check_version import version_requires
+from ansys.dpf.gate import support_capi, support_grpcapi
 
 
 class Support:

--- a/src/ansys/dpf/core/time_freq_scoping_factory.py
+++ b/src/ansys/dpf/core/time_freq_scoping_factory.py
@@ -27,16 +27,14 @@ time_freq_scoping_factory
 Contains functions to simplify creating time frequency scopings.
 """
 
-from ansys.dpf.core import Scoping
-from ansys.dpf.core import errors as dpf_errors
-from ansys.dpf.core.common import locations
-from ansys.dpf.core.model import Model
-from ansys.dpf.core.time_freq_support import TimeFreqSupport
-from ansys.dpf.core.data_sources import DataSources
-from ansys.dpf.core.operators.metadata import time_freq_provider
-
-from ansys.dpf.core import types
 from typing import Union
+
+from ansys.dpf.core import Scoping, errors as dpf_errors, types
+from ansys.dpf.core.common import locations
+from ansys.dpf.core.data_sources import DataSources
+from ansys.dpf.core.model import Model
+from ansys.dpf.core.operators.metadata import time_freq_provider
+from ansys.dpf.core.time_freq_support import TimeFreqSupport
 
 
 def scoping_by_load_step(load_step: int, server=None):

--- a/src/ansys/dpf/core/time_freq_support.py
+++ b/src/ansys/dpf/core/time_freq_support.py
@@ -27,12 +27,11 @@ TimeFreqSupport
 ===============
 """
 
-from ansys.dpf.gate import time_freq_support_capi, time_freq_support_grpcapi
-
 from ansys import dpf
 from ansys.dpf import core
 from ansys.dpf.core import errors as dpf_errors
 from ansys.dpf.core.support import Support
+from ansys.dpf.gate import time_freq_support_capi, time_freq_support_grpcapi
 
 
 class TimeFreqSupport(Support):

--- a/src/ansys/dpf/core/unit_system.py
+++ b/src/ansys/dpf/core/unit_system.py
@@ -28,8 +28,7 @@ UnitSystem
 """
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import errors as dpf_errors
-from ansys.dpf.core import server as server_module
+from ansys.dpf.core import errors as dpf_errors, server as server_module
 
 
 class UnitSystem:

--- a/src/ansys/dpf/core/vtk_helper.py
+++ b/src/ansys/dpf/core/vtk_helper.py
@@ -20,9 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from typing import Union
+
 import numpy as np
 import pyvista as pv
-from typing import Union
 from vtk import (
     VTK_HEXAHEDRON,
     VTK_LINE,

--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -27,31 +27,29 @@ Workflow
 ========
 """
 
+from enum import Enum
 import logging
 import os
 import traceback
+from typing import Union
 import warnings
 
-from enum import Enum
-from typing import Union
-
 from ansys import dpf
-from ansys.dpf.core import dpf_operator, inputs, outputs
+from ansys.dpf.core import dpf_operator, inputs, outputs, server as server_module
 from ansys.dpf.core.check_version import (
     server_meet_version,
-    version_requires,
     server_meet_version_and_raise,
+    version_requires,
 )
-from ansys.dpf.core import server as server_module
 from ansys.dpf.gate import (
-    workflow_abstract_api,
-    workflow_grpcapi,
-    workflow_capi,
     data_processing_capi,
     data_processing_grpcapi,
     dpf_vector,
-    object_handler,
     integral_types,
+    object_handler,
+    workflow_abstract_api,
+    workflow_capi,
+    workflow_grpcapi,
 )
 
 LOG = logging.getLogger(__name__)
@@ -249,22 +247,22 @@ class Workflow:
     @property
     def _type_to_input_method(self):
         from ansys.dpf.core import (
+            any,
+            collection,
+            custom_type_field,
             cyclic_support,
             data_sources,
-            field,
-            collection,
-            meshed_region,
-            property_field,
-            string_field,
-            custom_type_field,
-            scoping,
-            time_freq_support,
             data_tree,
-            workflow,
-            model,
+            field,
             generic_data_container,
-            any,
+            meshed_region,
+            model,
+            property_field,
+            scoping,
             streams_container,
+            string_field,
+            time_freq_support,
+            workflow,
         )
 
         out = [
@@ -312,26 +310,26 @@ class Workflow:
     @property
     def _type_to_output_method(self):
         from ansys.dpf.core import (
+            any,
+            collection,
+            collection_base,
+            custom_type_field,
             cyclic_support,
             data_sources,
+            data_tree,
             field,
             fields_container,
+            generic_data_container,
             meshed_region,
             meshes_container,
             property_field,
-            string_field,
-            custom_type_field,
             result_info,
             scoping,
             scopings_container,
-            time_freq_support,
-            data_tree,
-            workflow,
-            collection,
-            generic_data_container,
-            any,
-            collection_base,
             streams_container,
+            string_field,
+            time_freq_support,
+            workflow,
         )
 
         out = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,19 +26,19 @@ Launch or connect to a persistent local DPF service to be shared in
 pytest as a session fixture
 """
 
-import os
 import functools
+import os
+import warnings
 
 import psutil
 import pytest
 
-import ansys.dpf.core.server_types
 from ansys.dpf import core
 from ansys.dpf.core import examples
-from ansys.dpf.core.server_factory import ServerConfig, CommunicationProtocols
-from ansys.dpf.core.check_version import meets_version, get_server_version
+from ansys.dpf.core.check_version import get_server_version, meets_version
+from ansys.dpf.core.server_factory import CommunicationProtocols, ServerConfig
+import ansys.dpf.core.server_types
 from ansys.dpf.gate.load_api import _try_use_gatebin
-import warnings
 
 ACCEPTABLE_FAILURE_RATE = 0
 

--- a/tests/entry/conftest.py
+++ b/tests/entry/conftest.py
@@ -28,17 +28,17 @@ Launch or connect to a persistent local Entry DPF server to be shared in
 pytest as a session fixture
 """
 
-import os
 import functools
+import os
+
 import pytest
 
 os.environ["ANSYS_DPF_SERVER_CONTEXT"] = "ENTRY"  # MANDATORY
 
-import ansys.dpf.core.server_types
 from ansys.dpf import core
-from ansys.dpf.core.server_factory import ServerConfig, CommunicationProtocols
-from ansys.dpf.core.check_version import meets_version, get_server_version
-
+from ansys.dpf.core.check_version import get_server_version, meets_version
+from ansys.dpf.core.server_factory import CommunicationProtocols, ServerConfig
+import ansys.dpf.core.server_types
 
 core.set_default_server_context(core.AvailableServerContexts.entry)  # MANDATORY
 

--- a/tests/entry/test_entry.py
+++ b/tests/entry/test_entry.py
@@ -23,11 +23,11 @@
 import os
 
 import pytest
-import conftest
 
 import ansys.dpf.core as dpf
 from ansys.dpf.core import examples
 from ansys.dpf.core.core import errors
+import conftest
 from conftest import running_docker
 
 

--- a/tests/operators/test_coordinate_system.py
+++ b/tests/operators/test_coordinate_system.py
@@ -21,10 +21,11 @@
 # SOFTWARE.
 
 # Tests the result.coordinate_system operator
+import numpy as np
+
 import ansys.dpf.core as dpf
 from ansys.dpf.core import examples
 import conftest
-import numpy as np
 
 
 def test_operator_coordinate_system_rst(server_type):

--- a/tests/operators/test_operator_elemental_mass.py
+++ b/tests/operators/test_operator_elemental_mass.py
@@ -20,9 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import conftest
 import pytest
+
 import ansys.dpf.core as dpf
+import conftest
 
 
 @pytest.mark.skipif(

--- a/tests/operators/test_operator_mesh_plan_clip.py
+++ b/tests/operators/test_operator_mesh_plan_clip.py
@@ -20,9 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import pytest
+
 import ansys.dpf.core as dpf
 import conftest
-import pytest
 
 
 @pytest.mark.skipif(

--- a/tests/slow/test_remoteworkflow.py
+++ b/tests/slow/test_remoteworkflow.py
@@ -24,9 +24,8 @@ import numpy as np
 import pytest
 
 from ansys.dpf import core
-from ansys.dpf.core import examples
-from ansys.dpf.core import operators as ops
-from ansys.dpf.core.check_version import meets_version, get_server_version
+from ansys.dpf.core import examples, operators as ops
+from ansys.dpf.core.check_version import get_server_version, meets_version
 from conftest import local_servers
 
 SERVER_VERSION_HIGHER_THAN_3_0 = meets_version(get_server_version(core._global_server()), "3.0")

--- a/tests/slow/test_slow.py
+++ b/tests/slow/test_slow.py
@@ -20,8 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import pytest
 import numpy as np
+import pytest
 
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -25,10 +25,7 @@ import os
 import pytest
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import misc
-from ansys.dpf.core import examples
-from ansys.dpf.core import animation
-
+from ansys.dpf.core import animation, examples, misc
 
 if misc.module_exists("pyvista"):
     HAS_PYVISTA = True

--- a/tests/test_animator.py
+++ b/tests/test_animator.py
@@ -25,8 +25,7 @@ import os
 import pytest
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import misc, Workflow
-from ansys.dpf.core import examples
+from ansys.dpf.core import Workflow, examples, misc
 
 if misc.module_exists("pyvista"):
     HAS_PYVISTA = True

--- a/tests/test_any.py
+++ b/tests/test_any.py
@@ -22,8 +22,8 @@
 
 import pytest
 
-import conftest
 from ansys.dpf import core as dpf
+import conftest
 
 
 @conftest.raises_for_servers_version_under("7.0")

--- a/tests/test_cff.py
+++ b/tests/test_cff.py
@@ -21,8 +21,9 @@
 # SOFTWARE.
 
 import pytest
-import conftest
+
 from ansys.dpf import core as dpf
+import conftest
 
 
 @pytest.mark.skipif(

--- a/tests/test_checkversion.py
+++ b/tests/test_checkversion.py
@@ -22,9 +22,7 @@
 
 import pytest
 
-from ansys.dpf.core import check_version
-from ansys.dpf.core import errors as dpf_errors
-
+from ansys.dpf.core import check_version, errors as dpf_errors
 from ansys.dpf.gate.load_api import _find_outdated_ansys_version
 
 

--- a/tests/test_codegeneration.py
+++ b/tests/test_codegeneration.py
@@ -21,16 +21,16 @@
 # SOFTWARE.
 
 # -*- coding: utf-8 -*-
-import os
 import copy
+import os
 import tempfile
 
-import ansys.grpc.dpf
 import numpy as np
 
-import ansys.dpf.core.operators as op
 from ansys.dpf import core
 from ansys.dpf.core import examples
+import ansys.dpf.core.operators as op
+import ansys.grpc.dpf
 
 
 def test_workflowwithgeneratedcode(allkindofcomplexity):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -22,26 +22,27 @@
 
 # -*- coding: utf-8 -*-
 
-import conftest
+from dataclasses import dataclass, field
+import random
 
-import pytest
 import numpy as np
+import pytest
+
 from ansys.dpf.core import (
     CustomTypeField,
     CustomTypeFieldsCollection,
-    GenericDataContainersCollection,
-    StringFieldsCollection,
-    StringField,
     GenericDataContainer,
-    operators,
+    GenericDataContainersCollection,
+    StringField,
+    StringFieldsCollection,
     Workflow,
     fields_factory,
+    operators,
 )
 from ansys.dpf.core.collection import Collection
-from ansys.dpf.core.time_freq_support import TimeFreqSupport
 from ansys.dpf.core.generic_support import GenericSupport
-import random
-from dataclasses import dataclass, field
+from ansys.dpf.core.time_freq_support import TimeFreqSupport
+import conftest
 
 
 @conftest.raises_for_servers_version_under("8.1")

--- a/tests/test_custom_type_field.py
+++ b/tests/test_custom_type_field.py
@@ -22,10 +22,9 @@
 
 import numpy as np
 
-import conftest
-
 from ansys import dpf
 from ansys.dpf import core
+import conftest
 
 
 @conftest.raises_for_servers_version_under("5.0")

--- a/tests/test_cyclic_support.py
+++ b/tests/test_cyclic_support.py
@@ -22,8 +22,8 @@
 
 import gc
 import weakref
-import numpy as np
 
+import numpy as np
 import pytest
 
 from ansys import dpf

--- a/tests/test_data_tree.py
+++ b/tests/test_data_tree.py
@@ -20,9 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from ansys.dpf import core as dpf
 import os
+
 import pytest
+
+from ansys.dpf import core as dpf
 import conftest
 
 

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -20,11 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import weakref
+
 import pytest
 
 from ansys import dpf
 import conftest
-import weakref
 
 skip_always = pytest.mark.skipif(True, reason="Investigate why this is failing")
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -27,9 +27,7 @@ import os.path
 import pytest
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import Model
-from ansys.dpf.core import DataSources
-from ansys.dpf.core import examples
+from ansys.dpf.core import DataSources, Model, examples
 
 
 def test_download_all_kinds_of_complexity_modal():

--- a/tests/test_faces.py
+++ b/tests/test_faces.py
@@ -21,10 +21,11 @@
 # SOFTWARE.
 
 import pytest
-import conftest
+
 from ansys.dpf import core as dpf
-from ansys.dpf.core.elements import element_types
 from ansys.dpf.core import mesh_scoping_factory
+from ansys.dpf.core.elements import element_types
+import conftest
 
 
 @pytest.fixture()

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -23,12 +23,14 @@
 import numpy as np
 import pytest
 
-from ansys.dpf.core import Model
-from ansys.dpf.core import errors as dpf_errors
-from ansys.dpf.core import fields_container_factory
-from ansys.dpf.core import fields_factory
-from ansys.dpf.core import mesh_scoping_factory
-from ansys.dpf.core import time_freq_scoping_factory
+from ansys.dpf.core import (
+    Model,
+    errors as dpf_errors,
+    fields_container_factory,
+    fields_factory,
+    mesh_scoping_factory,
+    time_freq_scoping_factory,
+)
 from ansys.dpf.core.common import locations
 
 

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -20,18 +20,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import numpy as np
-import pytest
 import copy
 import gc
+
+import numpy as np
+import pytest
+
 from ansys import dpf
-import conftest
 from ansys.dpf import core
-from ansys.dpf.core import FieldDefinition
-from ansys.dpf.core import operators as ops
-from ansys.dpf.core.common import locations, shell_layers
-from conftest import running_docker, SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_8_0
+from ansys.dpf.core import FieldDefinition, operators as ops
 from ansys.dpf.core.check_version import server_meet_version
+from ansys.dpf.core.common import locations, shell_layers
+import conftest
+from conftest import SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_8_0, running_docker
 
 
 @pytest.fixture()

--- a/tests/test_fieldscontainer.py
+++ b/tests/test_fieldscontainer.py
@@ -20,24 +20,28 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import os
 import weakref
 
 import numpy as np
 import pytest
-import os
 
-import conftest
-from ansys.dpf.core.check_version import server_meet_version
 from ansys.dpf import core as dpf
-from ansys.dpf.core import FieldsContainer, Field, TimeFreqSupport
-from ansys.dpf.core import errors as dpf_errors
-from ansys.dpf.core import examples
-from ansys.dpf.core import fields_factory
-from ansys.dpf.core import operators as ops
-from ansys.dpf.core.custom_fields_container import (
-    ElShapeFieldsContainer,
-    BodyFieldsContainer,
+from ansys.dpf.core import (
+    Field,
+    FieldsContainer,
+    TimeFreqSupport,
+    errors as dpf_errors,
+    examples,
+    fields_factory,
+    operators as ops,
 )
+from ansys.dpf.core.check_version import server_meet_version
+from ansys.dpf.core.custom_fields_container import (
+    BodyFieldsContainer,
+    ElShapeFieldsContainer,
+)
+import conftest
 
 
 @pytest.fixture()

--- a/tests/test_generic_data_container.py
+++ b/tests/test_generic_data_container.py
@@ -21,15 +21,15 @@
 # SOFTWARE.
 
 import numpy as np
+import pytest
 
 from ansys.dpf import core as dpf
+import conftest
 from conftest import (
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_0,
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_8_0,
     raises_for_servers_version_under,
 )
-import pytest
-import conftest
 
 
 @conftest.raises_for_servers_version_under("7.0")

--- a/tests/test_genericsupport.py
+++ b/tests/test_genericsupport.py
@@ -20,8 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import conftest
 from ansys.dpf import core as dpf
+import conftest
 
 
 @conftest.raises_for_servers_version_under("5.0")

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -24,22 +24,22 @@ import numpy as np
 import pytest
 
 from ansys.dpf.core.geometry import (
-    Points,
     Line,
     Plane,
-    normalize_vector,
-    get_plane_local_axis,
-    get_local_coords_from_global,
+    Points,
     get_global_coords_from_local,
+    get_local_coords_from_global,
+    get_plane_local_axis,
+    normalize_vector,
 )
 from ansys.dpf.core.geometry_factory import (
-    create_points,
     create_line_from_points,
     create_line_from_vector,
     create_plane_from_center_and_normal,
-    create_plane_from_points,
     create_plane_from_lines,
     create_plane_from_point_and_line,
+    create_plane_from_points,
+    create_points,
     get_center_from_coords,
 )
 

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -22,7 +22,6 @@
 
 from ansys.dpf import core
 
-
 # try:
 #     core.BaseService(load_operators=False)._load_hdf5_operators()
 #     hdf5_loaded = True

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -20,10 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from ansys.dpf import core
-from ansys.dpf.core import common
 import numpy as np
 import pytest
+
+from ansys.dpf import core
+from ansys.dpf.core import common
 import conftest
 
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -20,18 +20,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import io
 import os
-
-import pytest
-import psutil
 import subprocess
 import sys
-import io
+
+import psutil
+import pytest
+
 from ansys.dpf import core
 from conftest import (
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_4_0,
-    configsserver_type,
     config_namesserver_type,
+    configsserver_type,
     running_docker,
 )
 
@@ -214,8 +215,9 @@ class TestServerConfigs:
 
 @pytest.mark.skipif(running_docker, reason="Not made to work on docker")
 def test_start_local_failed_executable(remote_config_server_type):
-    from ansys.dpf.core.misc import get_ansys_path
     from pathlib import Path
+
+    from ansys.dpf.core.misc import get_ansys_path
 
     with pytest.raises(FileNotFoundError):
         path = Path(get_ansys_path()).parent.absolute()

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -23,12 +23,12 @@
 import sys
 from unittest.mock import create_autospec
 
-import ansys.platform.instancemanagement as pypim
 import grpc
 import pytest
 
 from ansys.dpf.core import server_types
 from ansys.dpf.core.server_factory import ServerFactory
+import ansys.platform.instancemanagement as pypim
 from conftest import running_docker
 
 
@@ -38,7 +38,7 @@ def test_start_remote(monkeypatch):
 
     # Start a local DPF server and create a mock PyPIM pretending it is starting it
     from ansys.dpf import core
-    from ansys.dpf.core.server_factory import ServerConfig, CommunicationProtocols
+    from ansys.dpf.core.server_factory import CommunicationProtocols, ServerConfig
 
     conf = ServerConfig(protocol=CommunicationProtocols.gRPC, legacy=True)
     local_server = core.start_local_server(as_global=False, config=conf)

--- a/tests/test_local_server.py
+++ b/tests/test_local_server.py
@@ -22,8 +22,8 @@
 
 import numpy as np
 
-from ansys.dpf.core import operators as ops
 from ansys import dpf
+from ansys.dpf.core import operators as ops
 
 
 def test_add_operator_server_field(local_server):

--- a/tests/test_lsdyna.py
+++ b/tests/test_lsdyna.py
@@ -22,9 +22,10 @@
 
 import numpy as np
 import pytest
-import conftest
+
 from ansys.dpf import core as dpf
 from ansys.dpf.core.check_version import server_meet_version
+import conftest
 
 
 @pytest.mark.skipif(

--- a/tests/test_mesh_info.py
+++ b/tests/test_mesh_info.py
@@ -20,13 +20,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import ansys.dpf.core.generic_data_container
+import pytest
+
 from ansys.dpf import core as dpf
+from ansys.dpf.core import examples
+import ansys.dpf.core.generic_data_container
 from conftest import (
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_0,
 )
-import pytest
-from ansys.dpf.core import examples
 
 
 @pytest.mark.skipif(

--- a/tests/test_meshescontainer.py
+++ b/tests/test_meshescontainer.py
@@ -26,9 +26,9 @@ import weakref
 
 import pytest
 
-import conftest
 from ansys import dpf
 from ansys.dpf.core import MeshesContainer
+import conftest
 
 
 # TO DO: add server type

--- a/tests/test_meshregion.py
+++ b/tests/test_meshregion.py
@@ -25,8 +25,8 @@ import pytest
 import vtk
 
 from ansys import dpf
-import conftest
 from ansys.dpf.core.check_version import server_meet_version
+import conftest
 
 
 @pytest.fixture()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -27,9 +27,9 @@ import pytest
 
 from ansys import dpf
 from ansys.dpf.core import examples, misc
+from ansys.dpf.core.check_version import server_meet_version
 from ansys.dpf.core.errors import ServerTypeError
 from conftest import SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_4_0
-from ansys.dpf.core.check_version import server_meet_version
 
 NO_PLOTTING = True
 

--- a/tests/test_multi_server.py
+++ b/tests/test_multi_server.py
@@ -22,11 +22,11 @@
 
 import numpy as np
 import pytest
-import conftest
 
 from ansys.dpf import core as dpf
-from ansys.dpf.core import examples, server_types, server
-from ansys.dpf.core.server_factory import ServerConfig, CommunicationProtocols
+from ansys.dpf.core import examples, server, server_types
+from ansys.dpf.core.server_factory import CommunicationProtocols, ServerConfig
+import conftest
 
 if conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_6_0:
     dpf.set_default_server_context(dpf.AvailableServerContexts.entry)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import copy
 import gc
 import os
 import shutil
@@ -28,11 +29,9 @@ import weakref
 
 import numpy as np
 import pytest
-import copy
 
 from ansys import dpf
-from ansys.dpf.core import errors
-from ansys.dpf.core import operators as ops
+from ansys.dpf.core import errors, operators as ops
 from ansys.dpf.core.misc import get_ansys_path
 from ansys.dpf.core.operator_specification import Specification
 import conftest

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -26,8 +26,9 @@ Verify all examples can be accessed or downloaded
 """
 
 import pytest
-from conftest import SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_4_0
+
 from ansys.dpf import core as dpf
+from conftest import SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_4_0
 
 
 @pytest.mark.skipif(

--- a/tests/test_pathsupport.py
+++ b/tests/test_pathsupport.py
@@ -21,13 +21,14 @@
 # SOFTWARE.
 
 # Tests specific to pathlib.Path support as path argument instead of str
-import pytest
 import functools
 import os
-from conftest import running_docker
+from pathlib import Path
+
+import pytest
 
 from ansys import dpf
-from pathlib import Path
+from conftest import running_docker
 
 skip_always = pytest.mark.skipif(True, reason="Investigate why this is failing")
 

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -26,17 +26,15 @@ import pytest
 
 from ansys import dpf
 from ansys.dpf import core
-from ansys.dpf.core import Model, Operator
-from ansys.dpf.core import errors as dpf_errors
-from ansys.dpf.core import misc
+from ansys.dpf.core import Model, Operator, element_types, errors as dpf_errors, misc
 from ansys.dpf.core.plotter import plot_chart
-from conftest import running_docker, SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_5_0
-from ansys.dpf.core import element_types
+from conftest import SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_5_0, running_docker
 
 if misc.module_exists("pyvista"):
     HAS_PYVISTA = True
-    from ansys.dpf.core.plotter import DpfPlotter, Plotter
     from pyvista.plotting.renderer import CameraPosition  # noqa: F401
+
+    from ansys.dpf.core.plotter import DpfPlotter, Plotter
 else:
     HAS_PYVISTA = False
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -24,9 +24,9 @@ import os.path
 
 import pytest
 
-from conftest import SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_5_0
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
+from conftest import SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_5_0
 
 
 @pytest.fixture()

--- a/tests/test_property_fields_container.py
+++ b/tests/test_property_fields_container.py
@@ -22,8 +22,8 @@
 
 import pytest
 
-from ansys.dpf.core.property_fields_container import _MockPropertyFieldsContainer, _LabelSpaceKV
 from ansys.dpf import core as dpf
+from ansys.dpf.core.property_fields_container import _LabelSpaceKV, _MockPropertyFieldsContainer
 
 
 def test_property_fields_container(allkindofcomplexity, server_type):

--- a/tests/test_propertyfield.py
+++ b/tests/test_propertyfield.py
@@ -20,15 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import copy
+import gc
+
 import numpy as np
 import pytest
-import copy
-import conftest
-import gc
 
 from ansys import dpf
 from ansys.dpf import core
 from ansys.dpf.core.common import locations, natures
+import conftest
 
 
 @pytest.fixture()

--- a/tests/test_python_plugins.py
+++ b/tests/test_python_plugins.py
@@ -20,22 +20,24 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import pytest
 import os
 import platform
+
 import numpy as np
-from conftest import SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_4_0
+import pytest
+
 from ansys.dpf import core as dpf
-import conftest
 from ansys.dpf.core.custom_operator import update_virtual_environment_for_custom_operators
 from ansys.dpf.core.errors import DPFServerException
 from ansys.dpf.core.operator_specification import (
-    CustomSpecification,
-    SpecificationProperties,
     CustomConfigOptionSpec,
+    CustomSpecification,
     PinSpecification,
+    SpecificationProperties,
 )
+import conftest
 from conftest import (
+    SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_4_0,
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_7_0,
 )
 

--- a/tests/test_remote_operator.py
+++ b/tests/test_remote_operator.py
@@ -21,11 +21,12 @@
 # SOFTWARE.
 
 import numpy as np
-from conftest import local_servers
-import conftest
+import pytest
+
 from ansys.dpf import core
 from ansys.dpf.core import operators as ops
-import pytest
+import conftest
+from conftest import local_servers
 
 
 @pytest.mark.skipif(

--- a/tests/test_remote_workflow.py
+++ b/tests/test_remote_workflow.py
@@ -26,11 +26,10 @@ import numpy as np
 import pytest
 
 from ansys.dpf import core
-from ansys.dpf.core import examples
+from ansys.dpf.core import examples, operators as ops
 from ansys.dpf.core.errors import ServerTypeError
-from ansys.dpf.core import operators as ops
-from conftest import local_servers, running_docker
 import conftest
+from conftest import local_servers, running_docker
 
 
 @pytest.mark.xfail(raises=ServerTypeError)

--- a/tests/test_scoping.py
+++ b/tests/test_scoping.py
@@ -20,15 +20,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import copy
+
 import numpy as np
 import pytest
 
 from ansys import dpf
+from ansys.dpf.core import Scoping, errors as dpf_errors
 import conftest
 from conftest import SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2_0
-import copy
-from ansys.dpf.core import Scoping
-from ansys.dpf.core import errors as dpf_errors
 
 
 def test_create_scoping():

--- a/tests/test_scopingscontainer.py
+++ b/tests/test_scopingscontainer.py
@@ -23,11 +23,11 @@
 # -*- coding: utf-8 -*-
 import weakref
 
-import pytest
 import numpy as np
+import pytest
 
-import conftest
 from ansys.dpf.core import Scoping, ScopingsContainer
+import conftest
 
 
 @pytest.fixture()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -20,28 +20,32 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import os
+import platform
+import subprocess
+import sys
 import time
 
-import pytest
-import subprocess
-import platform
-import psutil
-import sys
-import os
 import packaging.version
+import psutil
+import pytest
 
 from ansys import dpf
-from ansys.dpf.core import errors, server_types
-from ansys.dpf.core.server_factory import ServerConfig, CommunicationProtocols
-from ansys.dpf.core.server import set_server_configuration, _global_server
-from ansys.dpf.core.server import start_local_server, connect_to_server
-from ansys.dpf.core.server import shutdown_all_session_servers, has_local_server
-from ansys.dpf.core.server import get_or_create_server
-from ansys.dpf.core import server
+from ansys.dpf.core import errors, server, server_types
+from ansys.dpf.core.server import (
+    _global_server,
+    connect_to_server,
+    get_or_create_server,
+    has_local_server,
+    set_server_configuration,
+    shutdown_all_session_servers,
+    start_local_server,
+)
+from ansys.dpf.core.server_factory import CommunicationProtocols, ServerConfig
 from conftest import (
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_4_0,
-    running_docker,
     remove_none_available_config,
+    running_docker,
 )
 
 server_configs, server_configs_names = remove_none_available_config(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -20,18 +20,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import datetime
+from importlib import reload
 import os
+import pkgutil
+import platform
 
 import pytest
-import conftest
-import pkgutil
-import datetime
-import platform
-from importlib import reload
 
 from ansys import dpf
-from ansys.dpf.core import path_utilities
-from ansys.dpf.core import examples
+from ansys.dpf.core import examples, path_utilities
+import conftest
 from conftest import running_docker
 
 
@@ -299,7 +298,7 @@ def test_dpf_join(server_type):
     reason="GrpcServer class is " "supported starting server version 4.0",
 )
 def test_load_api_without_awp_root(restore_awp_root):
-    from ansys.dpf.core.server_factory import ServerConfig, CommunicationProtocols
+    from ansys.dpf.core.server_factory import CommunicationProtocols, ServerConfig
 
     legacy_conf = ServerConfig(protocol=CommunicationProtocols.gRPC, legacy=True)
     loc_serv = dpf.core.start_local_server(config=legacy_conf, as_global=False)
@@ -332,7 +331,7 @@ def test_load_api_without_awp_root(restore_awp_root):
 )
 def test_load_api_with_awp_root():
     # with awp_root
-    from ansys.dpf.core.server_factory import ServerConfig, CommunicationProtocols
+    from ansys.dpf.core.server_factory import CommunicationProtocols, ServerConfig
 
     conf = ServerConfig(protocol=CommunicationProtocols.gRPC, legacy=False)
     serv_2 = dpf.core.start_local_server(config=conf, as_global=False)
@@ -350,7 +349,7 @@ def test_load_api_with_awp_root():
     reason="GrpcServer class is " "supported starting server version 4.0",
 )
 def test_load_api_with_awp_root_2():
-    from ansys.dpf.core.server_factory import ServerConfig, CommunicationProtocols
+    from ansys.dpf.core.server_factory import CommunicationProtocols, ServerConfig
 
     legacy_conf = ServerConfig(protocol=CommunicationProtocols.gRPC, legacy=True)
     loc_serv = dpf.core.start_local_server(config=legacy_conf, as_global=False)
@@ -377,7 +376,7 @@ def test_load_api_with_awp_root_2():
     reason="GrpcServer class is " "supported starting server version 4.0",
 )
 def test_load_api_without_awp_root_no_gatebin(restore_awp_root):
-    from ansys.dpf.core.server_factory import ServerConfig, CommunicationProtocols
+    from ansys.dpf.core.server_factory import CommunicationProtocols, ServerConfig
 
     legacy_conf = ServerConfig(protocol=CommunicationProtocols.gRPC, legacy=True)
     loc_serv = dpf.core.start_local_server(config=legacy_conf, as_global=False)
@@ -412,7 +411,7 @@ def test_load_api_without_awp_root_no_gatebin(restore_awp_root):
 )
 def test_load_api_with_awp_root_no_gatebin():
     # with awp_root
-    from ansys.dpf.core.server_factory import ServerConfig, CommunicationProtocols
+    from ansys.dpf.core.server_factory import CommunicationProtocols, ServerConfig
 
     conf = ServerConfig(protocol=CommunicationProtocols.gRPC, legacy=False)
     serv_2 = dpf.core.start_local_server(config=conf, as_global=False)
@@ -434,7 +433,7 @@ def test_load_api_with_awp_root_no_gatebin():
     reason="GrpcServer class is " "supported starting server version 4.0",
 )
 def test_load_api_with_awp_root_2_no_gatebin():
-    from ansys.dpf.core.server_factory import ServerConfig, CommunicationProtocols
+    from ansys.dpf.core.server_factory import CommunicationProtocols, ServerConfig
 
     legacy_conf = ServerConfig(protocol=CommunicationProtocols.gRPC, legacy=True)
     loc_serv = dpf.core.start_local_server(config=legacy_conf, as_global=False)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -21,10 +21,11 @@
 # SOFTWARE.
 
 import os
-import conftest
 import tempfile
+
 from ansys.dpf import core
 from ansys.dpf.core import examples
+import conftest
 
 
 def get_log_file(log_path, server):

--- a/tests/test_stringfield.py
+++ b/tests/test_stringfield.py
@@ -21,11 +21,11 @@
 # SOFTWARE.
 
 import numpy as np
-import conftest
 
 from ansys import dpf
 from ansys.dpf import core
 from ansys.dpf.core.common import locations
+import conftest
 
 
 @conftest.raises_for_servers_version_under("5.0")

--- a/tests/test_timefreqsupport.py
+++ b/tests/test_timefreqsupport.py
@@ -20,14 +20,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import numpy as np
-import pytest
 import weakref
 
+import numpy as np
+import pytest
+
 from ansys import dpf
-from ansys.dpf.core import TimeFreqSupport, Model
-from ansys.dpf.core import examples
-from ansys.dpf.core import fields_factory
+from ansys.dpf.core import Model, TimeFreqSupport, examples, fields_factory
 from ansys.dpf.core.common import locations
 import conftest
 
@@ -319,8 +318,9 @@ def test_workflow_connect_get_output_time_freq_support(velocity_acceleration):
 @pytest.mark.skipif(True, reason="used to check memory leaks")
 def test_timefreqsupport_memory_leaks():
     import gc
+
     from ansys.dpf.core import start_local_server
-    from ansys.dpf.core.server_factory import ServerConfig, CommunicationProtocols
+    from ansys.dpf.core.server_factory import CommunicationProtocols, ServerConfig
 
     config = ServerConfig(protocol=CommunicationProtocols.gRPC, legacy=True)
     # config = ServerConfig(protocol=CommunicationProtocols.gRPC)

--- a/tests/test_unit_systems.py
+++ b/tests/test_unit_systems.py
@@ -21,9 +21,10 @@
 # SOFTWARE.
 
 import pytest
-import conftest
+
 from ansys.dpf import core as dpf
 from ansys.dpf.core import errors as dpf_errors
+import conftest
 
 
 @pytest.mark.skipif(

--- a/tests/test_vtk_translate.py
+++ b/tests/test_vtk_translate.py
@@ -21,18 +21,19 @@
 # SOFTWARE.
 
 import pytest
-import conftest
+
 import ansys.dpf.core as dpf
 from ansys.dpf.core import errors, misc
 from ansys.dpf.core.vtk_helper import (
-    dpf_mesh_to_vtk,
-    dpf_field_to_vtk,
-    dpf_meshes_to_vtk,
-    dpf_fieldscontainer_to_vtk,
-    dpf_property_field_to_vtk,
     append_field_to_grid,
     append_fieldscontainer_to_grid,
+    dpf_field_to_vtk,
+    dpf_fieldscontainer_to_vtk,
+    dpf_mesh_to_vtk,
+    dpf_meshes_to_vtk,
+    dpf_property_field_to_vtk,
 )
+import conftest
 
 if misc.module_exists("pyvista"):
     HAS_PYVISTA = True

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -21,15 +21,15 @@
 # SOFTWARE.
 
 import os
+import platform
 
 import numpy as np
 import pytest
-import platform
 
-import ansys.dpf.core.operators as op
-import conftest
 from ansys import dpf
 from ansys.dpf.core import misc
+import ansys.dpf.core.operators as op
+import conftest
 
 if misc.module_exists("graphviz"):
     HAS_GRAPHVIZ = True
@@ -899,8 +899,8 @@ def test_create_on_other_server_and_connect_workflow(allkindofcomplexity, local_
 
 
 def deep_copy_using_workflow(dpf_entity, server, stream_type=1):
+    from ansys.dpf.core.common import types, types_enum_to_types
     from ansys.dpf.core.operators.serialization import serializer_to_string, string_deserializer
-    from ansys.dpf.core.common import types_enum_to_types, types
 
     entity_server = dpf_entity._server if hasattr(dpf_entity, "_server") else None
     serializer_wf = dpf.core.Workflow(server=entity_server)

--- a/tests/testfiles/pythonPlugins/all_types/dpf_types_op.py
+++ b/tests/testfiles/pythonPlugins/all_types/dpf_types_op.py
@@ -20,20 +20,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from ansys.dpf.core.custom_operator import CustomOperatorBase
 from ansys.dpf.core import (
-    field,
-    scoping,
-    fields_container,
-    meshes_container,
-    scopings_container,
-    property_field,
     data_sources,
+    data_tree,
+    field,
+    fields_container,
+    generic_data_container,
+    meshes_container,
+    property_field,
+    scoping,
+    scopings_container,
     types,
     workflow,
-    data_tree,
-    generic_data_container,
 )
+from ansys.dpf.core.custom_operator import CustomOperatorBase
 
 
 class ForwardFieldOperator(CustomOperatorBase):

--- a/tests/testfiles/pythonPlugins/all_types/integral_types_op.py
+++ b/tests/testfiles/pythonPlugins/all_types/integral_types_op.py
@@ -20,13 +20,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from ansys.dpf.core import types
 from ansys.dpf.core.custom_operator import CustomOperatorBase
 from ansys.dpf.core.operator_specification import (
     CustomSpecification,
     PinSpecification,
     SpecificationProperties,
 )
-from ansys.dpf.core import types
 
 
 class ForwardIntOperator(CustomOperatorBase):

--- a/tests/testfiles/pythonPlugins/all_types/load_operators_func.py
+++ b/tests/testfiles/pythonPlugins/all_types/load_operators_func.py
@@ -20,8 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from all_types import dpf_types_op, integral_types_op
 from ansys.dpf.core.custom_operator import record_operator
-from all_types import integral_types_op, dpf_types_op
 
 
 def load_operators(*args):

--- a/tests/testfiles/pythonPlugins/operator_with_spec.py
+++ b/tests/testfiles/pythonPlugins/operator_with_spec.py
@@ -20,12 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from ansys.dpf.core.custom_operator import CustomOperatorBase, record_operator
 from ansys.dpf.core import Field
+from ansys.dpf.core.custom_operator import CustomOperatorBase, record_operator
 from ansys.dpf.core.operator_specification import (
     CustomSpecification,
-    SpecificationProperties,
     PinSpecification,
+    SpecificationProperties,
 )
 
 

--- a/tests/testfiles/pythonPlugins/syntax_error_plugin/load_operators_func.py
+++ b/tests/testfiles/pythonPlugins/syntax_error_plugin/load_operators_func.py
@@ -20,8 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from ansys.dpf.core.custom_operator import record_operator
-from ansys.dpf.core.custom_operator import CustomOperatorBase
+from ansys.dpf.core.custom_operator import CustomOperatorBase, record_operator
 
 
 class SyntaxeError(CustomOperatorBase):


### PR DESCRIPTION
This pull-request is a continuation of #1727. It enables [isort](https://docs.astral.sh/ruff/rules/#isort-i) and applies the configuration to the codebase.