### PR TITLE
Fix minimal required protobuf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "importlib-metadata >=4.0",
     "numpy<2",
     "packaging",
-    "protobuf",
+    "protobuf>=5.27.0",
     "psutil",
     "setuptools",
     "tqdm",


### PR DESCRIPTION
Due to runtime_version.py shown as missing for previous versions.
See [here](https://github.com/ansys/pydpf-core/actions/runs/11127183318) for the CI run with `protobuf<5.27.0`.