### PR TITLE
Fix Coordinate System example retro on Docker

### DIFF
--- a/examples/10-mesh_operations/13-nodes_in_local_coordinate_system.py
+++ b/examples/10-mesh_operations/13-nodes_in_local_coordinate_system.py
@@ -59,7 +59,7 @@ try:
     # Starting with DPF 2025.1.pre1
     cs = dpf.operators.result.coordinate_system()
     cs.inputs.data_sources.connect(model)
-except KeyError:
+except KeyError, ansys.dpf.gate.errors.DPFServerException:
     # For previous DPF versions
     cs = model.operator(r"mapdl::rst::CS")
 

--- a/examples/10-mesh_operations/13-nodes_in_local_coordinate_system.py
+++ b/examples/10-mesh_operations/13-nodes_in_local_coordinate_system.py
@@ -59,7 +59,7 @@ try:
     # Starting with DPF 2025.1.pre1
     cs = dpf.operators.result.coordinate_system()
     cs.inputs.data_sources.connect(model)
-except KeyError, ansys.dpf.gate.errors.DPFServerException:
+except (KeyError, ansys.dpf.gate.errors.DPFServerException) as e:
     # For previous DPF versions
     cs = model.operator(r"mapdl::rst::CS")
 


### PR DESCRIPTION
On Docker, older servers do not raise a KeyError but a DPFServerException.
See [here](https://github.com/ansys/pydpf-core/actions/runs/11314623722/job/31464828501#step:14:45) for a failing CI_release pipeline targetting `DPF 2025.1.pre0`.