### PR TITLE
adapt logo for light and dark modes

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -7,7 +7,7 @@ import numpy as np
 import pyvista
 from ansys.dpf.core import __version__, server, server_factory
 from ansys.dpf.core.examples import get_example_required_minimum_dpf_version
-from ansys_sphinx_theme import pyansys_logo_black, ansys_favicon, get_version_match
+from ansys_sphinx_theme import ansys_favicon, get_version_match, pyansys_logo_light_mode, pyansys_logo_dark_mode
 
 # Manage errors
 pyvista.set_error_output_file("errors.txt")
@@ -193,9 +193,12 @@ autodoc_member_order = "bysource"
 # -- Options for HTML output -------------------------------------------------
 html_short_title = html_title = "PyDPF-Core"
 html_theme = "ansys_sphinx_theme"
-html_logo = pyansys_logo_black
 html_favicon = ansys_favicon
 html_theme_options = {
+    "logo": {
+        "image_dark": pyansys_logo_dark_mode,
+        "image_light": pyansys_logo_light_mode,
+    },
     "github_url": "https://github.com/ansys/pydpf-core",
     "show_prev_next": False,
     "show_breadcrumbs": True,


### PR DESCRIPTION
As discussed in #1749 ([33fade6](https://github.com/ansys/pydpf-core/pull/1749/commits/33fade68ec366d400711f080eceec6f563fd789d))