### PR TITLE
Fix retro-compatibility for example 13-nodes_in_local_coordinate_system.py

### DIFF
--- a/examples/10-mesh_operations/13-nodes_in_local_coordinate_system.py
+++ b/examples/10-mesh_operations/13-nodes_in_local_coordinate_system.py
@@ -42,6 +42,7 @@ The script below demonstrates the methodology using PyDPF.
 # Import necessary modules
 from ansys.dpf import core as dpf
 from ansys.dpf.core import examples
+from ansys.dpf.gate.errors import DPFServerException
 
 
 ###############################################################################
@@ -59,7 +60,7 @@ try:
     # Starting with DPF 2025.1.pre1
     cs = dpf.operators.result.coordinate_system()
     cs.inputs.data_sources.connect(model)
-except (KeyError, ansys.dpf.gate.errors.DPFServerException) as e:
+except (KeyError, DPFServerException) as e:
     # For previous DPF versions
     cs = model.operator(r"mapdl::rst::CS")
 


### PR DESCRIPTION
This fixes retro-compatibility of the example with DPF versions below 9.1 for the `0.13.1` release.

Passing CI for `251.pre0`: https://github.com/ansys/pydpf-core/actions/runs/11666195430