### PR TITLE
Add CyclicSupport.cs, CyclicSupport.high_low_map & CyclicSupport.low_high_map

### DIFF
--- a/src/ansys/dpf/core/cyclic_support.py
+++ b/src/ansys/dpf/core/cyclic_support.py
@@ -305,7 +305,7 @@ class CyclicSupport:
         )
         return Scoping(scoping=expanded_ids, server=self._server)
 
-    def cs(self):
+    def cs(self) -> field.Field:
         """Coordinate system of the cyclic support.
 
         Examples
@@ -315,25 +315,24 @@ class CyclicSupport:
         >>> multi_stage = examples.download_multi_stage_cyclic_result()
         >>> cyc_support = Model(multi_stage).metadata.result_info.cyclic_support
         >>> cs = cyc_support.cs()
-        >>> print(expanded_scoping.ids)
         [12]
         """
 
         cs = self._api.cyclic_support_get_cs(self)
         return field.Field(field=cs, server=self._server)
 
-    def low_high_map(self, stage_num=0):
+    def low_high_map(self, stage_num: int = 0) -> property_field.PropertyField:
         """Retrieve a property field containing node map from low to high
         base sector of the given stage.
 
         Parameters
         ----------
-        stage_num : int, optional
+        stage_num:
             Number of the stage required (from 0 to num_stages).
 
         Returns
         -------
-        low_high_map : PropertyField
+        low_high_map:
             Node correspondence between low to high in the base sector of the given stage.
 
         Examples
@@ -348,18 +347,18 @@ class CyclicSupport:
         low_high_map = self._api.cyclic_support_get_low_high_map(self, stage_num)
         return property_field.PropertyField(property_field=low_high_map, server=self._server)
 
-    def high_low_map(self, stage_num=0):
+    def high_low_map(self, stage_num: int = 0) -> property_field.PropertyField:
         """Retrieve a property field containing node map from high to low
         base sector of the given stage.
 
         Parameters
         ----------
-        stage_num : int, optional
+        stage_num:
             Number of the stage required (from 0 to num_stages).
 
         Returns
         -------
-        low_high_map : PropertyField
+        low_high_map:
             Node correspondence between high to low in the base sector of the given stage.
 
         Examples

--- a/src/ansys/dpf/core/cyclic_support.py
+++ b/src/ansys/dpf/core/cyclic_support.py
@@ -315,7 +315,7 @@ class CyclicSupport:
         >>> multi_stage = examples.download_multi_stage_cyclic_result()
         >>> cyc_support = Model(multi_stage).metadata.result_info.cyclic_support
         >>> cs = cyc_support.cs()
-        [12]
+
         """
 
         cs = self._api.cyclic_support_get_cs(self)

--- a/src/ansys/dpf/core/cyclic_support.py
+++ b/src/ansys/dpf/core/cyclic_support.py
@@ -32,6 +32,7 @@ from ansys.dpf.gate import cyclic_support_capi, cyclic_support_grpcapi
 
 from ansys.dpf.core import server as server_module
 from ansys.dpf.core.scoping import Scoping
+from ansys.dpf.core import field, property_field
 
 
 class CyclicSupport:
@@ -303,6 +304,75 @@ class CyclicSupport:
             self, element_id, stage_num, sectors
         )
         return Scoping(scoping=expanded_ids, server=self._server)
+
+    def cs(self):
+        """Coordinate system of the cyclic support.
+
+        Examples
+        --------
+        >>> from ansys.dpf.core import Model
+        >>> from ansys.dpf.core import examples
+        >>> multi_stage = examples.download_multi_stage_cyclic_result()
+        >>> cyc_support = Model(multi_stage).metadata.result_info.cyclic_support
+        >>> cs = cyc_support.cs()
+        >>> print(expanded_scoping.ids)
+        [12]
+        """
+
+        cs = self._api.cyclic_support_get_cs(self)
+        return field.Field(field=cs, server=self._server)
+
+    def low_high_map(self, stage_num=0):
+        """Retrieve a property field containing node map from low to high
+        base sector of the given stage.
+
+        Parameters
+        ----------
+        stage_num : int, optional
+            Number of the stage required (from 0 to num_stages).
+
+        Returns
+        -------
+        low_high_map : PropertyField
+            Node correspondance between low to high in the base sector of the given stage.
+
+        Examples
+        --------
+        >>> from ansys.dpf.core import Model
+        >>> from ansys.dpf.core import examples
+        >>> multi_stage = examples.download_multi_stage_cyclic_result()
+        >>> cyc_support = Model(multi_stage).metadata.result_info.cyclic_support
+        >>> low_high_map = cyc_support.low_high_map(0)
+
+        """
+        low_high_map = self._api.cyclic_support_get_low_high_map(self, stage_num)
+        return property_field.PropertyField(property_field=low_high_map, server=self._server)
+
+    def high_low_map(self, stage_num=0):
+        """Retrieve a property field containing node map from high to low
+        base sector of the given stage.
+
+        Parameters
+        ----------
+        stage_num : int, optional
+            Number of the stage required (from 0 to num_stages).
+
+        Returns
+        -------
+        low_high_map : PropertyField
+            Node correspondance between high to low in the base sector of the given stage.
+
+        Examples
+        --------
+        >>> from ansys.dpf.core import Model
+        >>> from ansys.dpf.core import examples
+        >>> multi_stage = examples.download_multi_stage_cyclic_result()
+        >>> cyc_support = Model(multi_stage).metadata.result_info.cyclic_support
+        >>> high_low_map = cyc_support.high_low_map(0)
+
+        """
+        high_low_map = self._api.cyclic_support_get_high_low_map(self, stage_num)
+        return property_field.PropertyField(property_field=high_low_map, server=self._server)
 
     def __del__(self):
         try:

--- a/src/ansys/dpf/core/cyclic_support.py
+++ b/src/ansys/dpf/core/cyclic_support.py
@@ -334,7 +334,7 @@ class CyclicSupport:
         Returns
         -------
         low_high_map : PropertyField
-            Node correspondance between low to high in the base sector of the given stage.
+            Node correspondence between low to high in the base sector of the given stage.
 
         Examples
         --------
@@ -360,7 +360,7 @@ class CyclicSupport:
         Returns
         -------
         low_high_map : PropertyField
-            Node correspondance between high to low in the base sector of the given stage.
+            Node correspondence between high to low in the base sector of the given stage.
 
         Examples
         --------

--- a/src/ansys/dpf/gate/cyclic_support_grpcapi.py
+++ b/src/ansys/dpf/gate/cyclic_support_grpcapi.py
@@ -76,6 +76,16 @@ class CyclicSupportGRPCAPI(cyclic_support_abstract_api.CyclicSupportAbstractAPI)
                        "base_elements_scoping_"+str(i_stage)).get_ownership()
 
     @staticmethod
+    def cyclic_support_get_low_high_map(support, i_stage):
+        return getattr(CyclicSupportGRPCAPI.list(support),
+                       "low_high_map_"+str(i_stage)).get_ownership()
+
+    @staticmethod
+    def cyclic_support_get_high_low_map(support, i_stage):
+        return getattr(CyclicSupportGRPCAPI.list(support),
+                       "high_low_map_"+str(i_stage)).get_ownership()
+
+    @staticmethod
     def get_expanded_ids(support, request):
         return _get_stub(support._server).GetExpandedIds(request).expanded_ids
 
@@ -100,3 +110,19 @@ class CyclicSupportGRPCAPI(cyclic_support_abstract_api.CyclicSupportAbstractAPI)
         request = CyclicSupportGRPCAPI.init_get_expanded_ids(support, i_stage, sectorsScoping)
         request.element_id = baseElementId
         return CyclicSupportGRPCAPI.get_expanded_ids(support, request)
+
+    @staticmethod
+    def get_cs(support, request):
+        return _get_stub(support._server).GetCS(request).cs
+
+    @staticmethod
+    def init_get_cs(support):
+        from ansys.grpc.dpf import cyclic_support_pb2
+        request = cyclic_support_pb2.GetCSRequest()
+        request.support.CopyFrom(support._internal_obj)
+        return request
+
+    @staticmethod
+    def cyclic_support_get_cs(support):
+        request = CyclicSupportGRPCAPI.init_get_cs(support)
+        return CyclicSupportGRPCAPI.get_cs(support, request)

--- a/tests/test_cyclic_support.py
+++ b/tests/test_cyclic_support.py
@@ -94,8 +94,8 @@ def test_cyc_support_from_model(cyclic_lin_rst):
     exp = cyc_support.expand_element_id(1, [0, 1, 2])
     assert np.allclose(exp.ids, [1, 10, 19])
 
-    cs = cyc_support.cs()
-    assert np.allclose(cs.scoping.ids, [12])
+    exp = cyc_support.cs().scoping
+    assert np.allclose(exp.ids, [12])
 
 
 def test_cyc_support_from_to_operator(cyclic_lin_rst, server_type):
@@ -187,7 +187,7 @@ def test_cyc_support_multistage(cyclic_multistage):
     )
     assert np.allclose(cyc_support.sectors_set_for_expansion(stage_num=1).ids, list(range(0, 12)))
 
-    high_low_map = my_cyclic_support.high_low_map()
+    high_low_map = my_cyclic_support.high_low_map(0)
     assert np.allclose(high_low_map.get_entity_data_by_id(1446), 1447)
     assert np.allclose(high_low_map.get_entity_data_by_id(2946), 2948)
     assert np.allclose(high_low_map.get_entity_data_by_id(1452), 1466)
@@ -196,7 +196,6 @@ def test_cyc_support_multistage(cyclic_multistage):
     assert np.allclose(low_high_map.get_entity_data_by_id(995), 939)
     assert np.allclose(low_high_map.get_entity_data_by_id(53), 54)
     assert np.allclose(low_high_map.get_entity_data_by_id(70), 56)
-
 
 
 def test_delete_cyc_support(cyclic_lin_rst, server_type_legacy_grpc):

--- a/tests/test_cyclic_support.py
+++ b/tests/test_cyclic_support.py
@@ -187,12 +187,12 @@ def test_cyc_support_multistage(cyclic_multistage):
     )
     assert np.allclose(cyc_support.sectors_set_for_expansion(stage_num=1).ids, list(range(0, 12)))
 
-    high_low_map = my_cyclic_support.high_low_map(0)
+    high_low_map = cyc_support.high_low_map(0)
     assert np.allclose(high_low_map.get_entity_data_by_id(1446), 1447)
     assert np.allclose(high_low_map.get_entity_data_by_id(2946), 2948)
     assert np.allclose(high_low_map.get_entity_data_by_id(1452), 1466)
 
-    low_high_map = my_cyclic_support.low_high_map(1)
+    low_high_map = cyc_support.low_high_map(1)
     assert np.allclose(low_high_map.get_entity_data_by_id(995), 939)
     assert np.allclose(low_high_map.get_entity_data_by_id(53), 54)
     assert np.allclose(low_high_map.get_entity_data_by_id(70), 56)

--- a/tests/test_cyclic_support.py
+++ b/tests/test_cyclic_support.py
@@ -172,9 +172,7 @@ def test_cyc_support_from_to_workflow(cyclic_lin_rst, server_type):
     assert len(exp.base_nodes_scoping().ids) == 32
 
 
-
-
-@conftest.raises_for_servers_version_under("8.2")
+@pytest.mark.skipif(not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_8_2)
 def test_cyc_support_coordinate_system(cyclic_lin_rst):
     data_sources = dpf.DataSources(cyclic_lin_rst)
     model = dpf.Model(data_sources)
@@ -198,7 +196,7 @@ def test_cyc_support_multistage(cyclic_multistage):
     assert np.allclose(cyc_support.sectors_set_for_expansion(stage_num=1).ids, list(range(0, 12)))
 
 
-@conftest.raises_for_servers_version_under("8.2")
+@pytest.mark.skipif(not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_8_2)
 def test_cyc_support_multistage_low_high_map(cyclic_multistage):
     model = dpf.Model(cyclic_multistage)
     cyc_support = model.metadata.result_info.cyclic_support

--- a/tests/test_cyclic_support.py
+++ b/tests/test_cyclic_support.py
@@ -24,6 +24,7 @@ import gc
 import weakref
 import numpy as np
 
+import conftest
 import pytest
 
 from ansys import dpf
@@ -189,7 +190,7 @@ def test_cyc_support_multistage(cyclic_multistage):
 def test_cyc_support_multistage_low_high_map(cyclic_multistage):
     model = dpf.Model(cyclic_multistage)
     cyc_support = model.metadata.result_info.cyclic_support
-    
+
     high_low_map = cyc_support.high_low_map(0)
     assert np.allclose(high_low_map.get_entity_data_by_id(1446), 1447)
     assert np.allclose(high_low_map.get_entity_data_by_id(2946), 2948)

--- a/tests/test_cyclic_support.py
+++ b/tests/test_cyclic_support.py
@@ -172,6 +172,18 @@ def test_cyc_support_from_to_workflow(cyclic_lin_rst, server_type):
     assert len(exp.base_nodes_scoping().ids) == 32
 
 
+
+
+@conftest.raises_for_servers_version_under("8.2")
+def test_cyc_support_coordinate_system(cyclic_lin_rst):
+    data_sources = dpf.DataSources(cyclic_lin_rst)
+    model = dpf.Model(data_sources)
+    result_info = model.metadata.result_info
+    cyc_support = result_info.cyclic_support
+    exp = cyc_support.cs().scoping
+    assert np.allclose(exp.ids, [12])
+
+
 def test_cyc_support_multistage(cyclic_multistage):
     model = dpf.Model(cyclic_multistage)
     cyc_support = model.metadata.result_info.cyclic_support
@@ -187,8 +199,8 @@ def test_cyc_support_multistage(cyclic_multistage):
 
 
 @conftest.raises_for_servers_version_under("8.2")
-def test_cyc_support_multistage_low_high_map(cyclic_multistage, server_type):
-    model = dpf.Model(cyclic_multistage, server=server_type)
+def test_cyc_support_multistage_low_high_map(cyclic_multistage):
+    model = dpf.Model(cyclic_multistage)
     cyc_support = model.metadata.result_info.cyclic_support
 
     high_low_map = cyc_support.high_low_map(0)
@@ -200,18 +212,6 @@ def test_cyc_support_multistage_low_high_map(cyclic_multistage, server_type):
     assert np.allclose(low_high_map.get_entity_data_by_id(995), 939)
     assert np.allclose(low_high_map.get_entity_data_by_id(53), 54)
     assert np.allclose(low_high_map.get_entity_data_by_id(70), 56)
-
-
-@conftest.raises_for_servers_version_under("8.2")
-def test_cyc_support_coordinate_system(cyclic_lin_rst, server_type):
-    data_sources = dpf.DataSources(cyclic_lin_rst, server=server_type)
-    model = dpf.Model(data_sources, server=server_type)
-    result_info = model.metadata.result_info
-
-    cyc_support = result_info.cyclic_support
-
-    exp = cyc_support.cs().scoping
-    assert np.allclose(exp.ids, [12])
 
 
 def test_delete_cyc_support(cyclic_lin_rst, server_type_legacy_grpc):

--- a/tests/test_cyclic_support.py
+++ b/tests/test_cyclic_support.py
@@ -186,7 +186,7 @@ def test_cyc_support_multistage(cyclic_multistage):
     assert np.allclose(cyc_support.sectors_set_for_expansion(stage_num=1).ids, list(range(0, 12)))
 
 
-@conftest.raises_for_servers_version_under("8.2")
+@conftest.raises_for_servers_version_under("8.1")
 def test_cyc_support_multistage_low_high_map(cyclic_multistage):
     model = dpf.Model(cyclic_multistage)
     cyc_support = model.metadata.result_info.cyclic_support
@@ -202,7 +202,7 @@ def test_cyc_support_multistage_low_high_map(cyclic_multistage):
     assert np.allclose(low_high_map.get_entity_data_by_id(70), 56)
 
 
-@conftest.raises_for_servers_version_under("8.2")
+@conftest.raises_for_servers_version_under("8.1")
 def test_cyc_support_coordinate_system(cyclic_lin_rst):
     data_sources = dpf.DataSources(cyclic_lin_rst)
     model = dpf.Model(data_sources)

--- a/tests/test_cyclic_support.py
+++ b/tests/test_cyclic_support.py
@@ -94,9 +94,6 @@ def test_cyc_support_from_model(cyclic_lin_rst):
     exp = cyc_support.expand_element_id(1, [0, 1, 2])
     assert np.allclose(exp.ids, [1, 10, 19])
 
-    exp = cyc_support.cs().scoping
-    assert np.allclose(exp.ids, [12])
-
 
 def test_cyc_support_from_to_operator(cyclic_lin_rst, server_type):
     data_sources = dpf.DataSources(cyclic_lin_rst, server=server_type)
@@ -187,6 +184,12 @@ def test_cyc_support_multistage(cyclic_multistage):
     )
     assert np.allclose(cyc_support.sectors_set_for_expansion(stage_num=1).ids, list(range(0, 12)))
 
+
+@conftest.raises_for_servers_version_under("8.2")
+def test_cyc_support_multistage_low_high_map(cyclic_multistage):
+    model = dpf.Model(cyclic_multistage)
+    cyc_support = model.metadata.result_info.cyclic_support
+    
     high_low_map = cyc_support.high_low_map(0)
     assert np.allclose(high_low_map.get_entity_data_by_id(1446), 1447)
     assert np.allclose(high_low_map.get_entity_data_by_id(2946), 2948)
@@ -196,6 +199,18 @@ def test_cyc_support_multistage(cyclic_multistage):
     assert np.allclose(low_high_map.get_entity_data_by_id(995), 939)
     assert np.allclose(low_high_map.get_entity_data_by_id(53), 54)
     assert np.allclose(low_high_map.get_entity_data_by_id(70), 56)
+
+
+@conftest.raises_for_servers_version_under("8.2")
+def test_cyc_support_coordinate_system(cyclic_lin_rst):
+    data_sources = dpf.DataSources(cyclic_lin_rst)
+    model = dpf.Model(data_sources)
+    result_info = model.metadata.result_info
+
+    cyc_support = result_info.cyclic_support
+
+    exp = cyc_support.cs().scoping
+    assert np.allclose(exp.ids, [12])
 
 
 def test_delete_cyc_support(cyclic_lin_rst, server_type_legacy_grpc):

--- a/tests/test_cyclic_support.py
+++ b/tests/test_cyclic_support.py
@@ -94,6 +94,9 @@ def test_cyc_support_from_model(cyclic_lin_rst):
     exp = cyc_support.expand_element_id(1, [0, 1, 2])
     assert np.allclose(exp.ids, [1, 10, 19])
 
+    cs = cyc_support.cs()
+    assert np.allclose(cs.scoping.ids, [12])
+
 
 def test_cyc_support_from_to_operator(cyclic_lin_rst, server_type):
     data_sources = dpf.DataSources(cyclic_lin_rst, server=server_type)
@@ -183,6 +186,17 @@ def test_cyc_support_multistage(cyclic_multistage):
         [1, 3596, 5816, 8036, 10256, 12476],
     )
     assert np.allclose(cyc_support.sectors_set_for_expansion(stage_num=1).ids, list(range(0, 12)))
+
+    high_low_map = my_cyclic_support.high_low_map()
+    assert np.allclose(high_low_map.get_entity_data_by_id(1446), 1447)
+    assert np.allclose(high_low_map.get_entity_data_by_id(2946), 2948)
+    assert np.allclose(high_low_map.get_entity_data_by_id(1452), 1466)
+
+    low_high_map = my_cyclic_support.low_high_map(1)
+    assert np.allclose(low_high_map.get_entity_data_by_id(995), 939)
+    assert np.allclose(low_high_map.get_entity_data_by_id(53), 54)
+    assert np.allclose(low_high_map.get_entity_data_by_id(70), 56)
+
 
 
 def test_delete_cyc_support(cyclic_lin_rst, server_type_legacy_grpc):

--- a/tests/test_cyclic_support.py
+++ b/tests/test_cyclic_support.py
@@ -186,9 +186,9 @@ def test_cyc_support_multistage(cyclic_multistage):
     assert np.allclose(cyc_support.sectors_set_for_expansion(stage_num=1).ids, list(range(0, 12)))
 
 
-@conftest.raises_for_servers_version_under("8.1")
-def test_cyc_support_multistage_low_high_map(cyclic_multistage):
-    model = dpf.Model(cyclic_multistage)
+@conftest.raises_for_servers_version_under("8.2")
+def test_cyc_support_multistage_low_high_map(cyclic_multistage, server_type):
+    model = dpf.Model(cyclic_multistage, server=server_type)
     cyc_support = model.metadata.result_info.cyclic_support
 
     high_low_map = cyc_support.high_low_map(0)
@@ -202,10 +202,10 @@ def test_cyc_support_multistage_low_high_map(cyclic_multistage):
     assert np.allclose(low_high_map.get_entity_data_by_id(70), 56)
 
 
-@conftest.raises_for_servers_version_under("8.1")
-def test_cyc_support_coordinate_system(cyclic_lin_rst):
-    data_sources = dpf.DataSources(cyclic_lin_rst)
-    model = dpf.Model(data_sources)
+@conftest.raises_for_servers_version_under("8.2")
+def test_cyc_support_coordinate_system(cyclic_lin_rst, server_type):
+    data_sources = dpf.DataSources(cyclic_lin_rst, server=server_type)
+    model = dpf.Model(data_sources, server=server_type)
     result_info = model.metadata.result_info
 
     cyc_support = result_info.cyclic_support

--- a/tests/test_cyclic_support.py
+++ b/tests/test_cyclic_support.py
@@ -172,7 +172,9 @@ def test_cyc_support_from_to_workflow(cyclic_lin_rst, server_type):
     assert len(exp.base_nodes_scoping().ids) == 32
 
 
-@pytest.mark.skipif(not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_8_2)
+@pytest.mark.skipif(
+    not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_8_2, reason="Requires DPF 8.2 or above."
+)
 def test_cyc_support_coordinate_system(cyclic_lin_rst):
     data_sources = dpf.DataSources(cyclic_lin_rst)
     model = dpf.Model(data_sources)
@@ -196,7 +198,9 @@ def test_cyc_support_multistage(cyclic_multistage):
     assert np.allclose(cyc_support.sectors_set_for_expansion(stage_num=1).ids, list(range(0, 12)))
 
 
-@pytest.mark.skipif(not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_8_2)
+@pytest.mark.skipif(
+    not conftest.SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_8_2, reason="Requires DPF 8.2 or above."
+)
 def test_cyc_support_multistage_low_high_map(cyclic_multistage):
     model = dpf.Model(cyclic_multistage)
     cyc_support = model.metadata.result_info.cyclic_support


### PR DESCRIPTION
Following the tests made during the pyDPF training, this PR aims to enable using the methods cs, high_low_map & low_high_map in pyDPF.

![image](https://github.com/user-attachments/assets/e9bbc9bf-a889-4c5b-bc26-c7365b5f10e4)

![image](https://github.com/user-attachments/assets/f4fa4ecf-f0a7-452c-a752-35763c586571)


