### PR TITLE
Add a tutorial issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tutorial.yml
+++ b/.github/ISSUE_TEMPLATE/tutorial.yml
@@ -1,0 +1,16 @@
+name: 🎓 Adding a tutorial
+description: Proposing a new tutorial for the library
+title: "Tutorial proposal: ..."
+labels: ["tutorial"]
+assignees: [""]
+
+body:
+
+  - type: textarea
+    id: tutorial-description
+    attributes:
+      label: '📝 Description of the tutorial'
+      placeholder: Describe what tutorial you devised and why it is useful for the project.
+
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/tutorial.yml
+++ b/.github/ISSUE_TEMPLATE/tutorial.yml
@@ -1,7 +1,7 @@
 name: 🎓 Adding a tutorial
 description: Proposing a new tutorial for the library
 title: "Tutorial proposal: ..."
-labels: ["tutorial"]
+labels: ["tutorials"]
 assignees: [""]
 
 body:


### PR DESCRIPTION
This prepares the arrival of a new section in the `User Guide` section of the documentation for `Tutorials`.
This issue template will mark the corresponding proposal as related to tutorials to differentiate them from examples.