### PR TITLE
Fix example issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/examples.yml
+++ b/.github/ISSUE_TEMPLATE/examples.yml
@@ -1,7 +1,7 @@
 name: 🎓 Adding an example
 description: Proposing a new example for the library
 title: "Example proposal: ..."
-labels: ["example"]
+labels: ["examples"]
 assignees: [""]
 
 body:


### PR DESCRIPTION
The correct label used for examples in this repo is `examples` and not `example`.