### PR TITLE
fix: Sphinx button border and transparency style in docs

### DIFF
--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -2,19 +2,3 @@
 .wy-table-responsive table td, .wy-table-responsive table th {
     white-space: normal;
 }
-
-
-.bd-content .sd-card .sd-card-body, .bd-content .sd-card .sd-card-footer {
-    background-color: transparent;
-}
-
-html .sd-btn {
-    padding: 4px;
-    color: var(--ast-color-active-text)!important;
-    border-color: var(--ast-dropdown-border-color)!important;
-}
-.sd-card-text {
-    font-family: var(--pst-font-family-base);
-    font-size: var(--pst-font-size-base);
-}
-

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -18,6 +18,3 @@ html .sd-btn {
     font-size: var(--pst-font-size-base);
 }
 
-.sd-sphinx-override .code {
-   background-color: var(--pst-color-surface);
-}

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -8,6 +8,11 @@
     background-color: transparent;
 }
 
+html .sd-btn {
+    padding: 4px;
+    color: var(--ast-color-active-text)!important;
+    border-color: var(--ast-dropdown-border-color)!important;
+}
 .sd-card-text {
     font-family: var(--pst-font-family-base);
     font-size: var(--pst-font-size-base);

--- a/doc/source/operator_reference.rst
+++ b/doc/source/operator_reference.rst
@@ -26,7 +26,7 @@ Click below to access the operators documentation.
 
             +++
             .. button-link:: OPEN
-               :color: secondary
+               :color: primary
                :expand:
                :outline:
                :click-parent:              


### PR DESCRIPTION
fix #1900 
![image](https://github.com/user-attachments/assets/36d8e23f-0de6-41b2-8656-4f79f659a24f)
![image](https://github.com/user-attachments/assets/6ff6dddb-c8e3-49a8-97c1-b71c6471a356)
