### PR TITLE
Augment license check timeout in licensing example

### DIFF
--- a/.ci/run_examples.py
+++ b/.ci/run_examples.py
@@ -33,13 +33,13 @@ for root, subdirectories, files in os.walk(os.path.join(actual_path, os.path.par
             print(file)
             minimum_version_str = get_example_required_minimum_dpf_version(file)
             if float(server_version) - float(minimum_version_str) < -0.05:
-                print(f"Example skipped as it requires DPF {minimum_version_str}.")
+                print(f"Example skipped as it requires DPF {minimum_version_str}.", flush=True)
                 continue
             try:
                 out = subprocess.check_output([sys.executable, file])
             except subprocess.CalledProcessError as e:
                 sys.stderr.write(str(e.args))
                 if e.returncode != 3221225477:
-                    print(out)
+                    print(out, flush=True)
                     raise e
-            print("PASS")
+            print("PASS", flush=True)

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -132,7 +132,6 @@ jobs:
         shell: bash
         working-directory: .ci
         run: |
-          echo on
           python run_examples.py
 
       - name: "Kill all servers"

--- a/examples/04-advanced/13-manage_licensing.py
+++ b/examples/04-advanced/13-manage_licensing.py
@@ -104,7 +104,7 @@ print(out)
 # license increment is used, and for what maximum duration.
 
 # Use the LicenseContextManager to block a specific increment for a limited duration
-with dpf.LicenseContextManager(increment_name="preppost", license_timeout_in_seconds=1.0) as lic:
+with dpf.LicenseContextManager(increment_name="preppost", license_timeout_in_seconds=5.0) as lic:
     # Instantiate the licensed operator
     out = op_premium.eval()
     print(out)


### PR DESCRIPTION
The timeout was set to `1.0s`, which is sometimes too low on GitHub runners.