### PR TITLE
Fix warning condition on field location for compute_streamlines

### DIFF
--- a/src/ansys/dpf/core/helpers/streamlines.py
+++ b/src/ansys/dpf/core/helpers/streamlines.py
@@ -159,7 +159,7 @@ def compute_streamlines(meshed_region, field, **kwargs):
 
     """
     # Check velocity field location
-    if field.location is not locations.nodal:
+    if field.location != locations.nodal:
         warnings.warn(
             "Velocity field must have a nodal location. Result must be carefully checked."
         )


### PR DESCRIPTION
`is not` was returning true as they are not the same string instances, while `!=` does a real comparison.