### PR TITLE
Remove exclude of vtk 9.4.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -195,7 +195,7 @@ jobs:
         run: python -c "from ansys.dpf import core"
 
       - name: "Prepare Testing Environment"
-        uses: ansys/pydpf-actions/prepare_tests@v2.3
+        uses: ansys/pydpf-actions/prepare_tests@b3e834e74924dba7b26bad15001b83aec66b9ce9
         with:
           DEBUG: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ plotting = [
     "matplotlib>=3.2",
     # 3D plotting
     "pyvista>=0.32.0",
-    "vtk!=9.4.0",
     # Animations
     "imageio < 2.28.1",
     "imageio-ffmpeg",


### PR DESCRIPTION
This PR tests and validates the bump of `pydpf-actions/prepare_tests` to using `pyvista/setup-headless-display-action@v3` which should solve the issue with `vtk==9.4.0`.
Note that `pyvista==0.44.2` was just released which also excludes `vtk==9.4.0` until everything is fixed on their side.