### PR TITLE
Fix/examples custom operator downloads

### DIFF
--- a/examples/08-python-operators/00-wrapping_numpy_capabilities.py
+++ b/examples/08-python-operators/00-wrapping_numpy_capabilities.py
@@ -61,7 +61,7 @@ from ansys.dpf import core as dpf
 
 
 GITHUB_SOURCE_URL = (
-    "https://github.com/ansys/pydpf-core/" "raw/examples/first_python_plugins/python_plugins"
+    "https://github.com/ansys/pydpf-core/raw/master/doc/source/examples/07-python-operators/plugins"
 )
 EXAMPLE_FILE = GITHUB_SOURCE_URL + "/easy_statistics.py"
 operator_file_path = examples.downloads._retrieve_file(

--- a/examples/08-python-operators/00-wrapping_numpy_capabilities.py
+++ b/examples/08-python-operators/00-wrapping_numpy_capabilities.py
@@ -57,7 +57,6 @@ be wrapped in Python plugins.
 # Download and display the Python script.
 
 from ansys.dpf.core import examples
-from ansys.dpf import core as dpf
 
 
 GITHUB_SOURCE_URL = (

--- a/examples/08-python-operators/01-package_python_operators.py
+++ b/examples/08-python-operators/01-package_python_operators.py
@@ -62,18 +62,21 @@ from ansys.dpf import core as dpf
 
 
 print("\033[1m average_filter_plugin")
-file_list = ["__init__.py", "operators.py", "operators_loader.py", "common.py"]
+file_list = [
+    "average_filter_plugin/__init__.py",
+    "average_filter_plugin/operators.py",
+    "average_filter_plugin/operators_loader.py",
+    "average_filter_plugin/common.py",
+]
 plugin_folder = None
 GITHUB_SOURCE_URL = (
     "https://github.com/ansys/pydpf-core/raw/"
-    "examples/first_python_plugins/python_plugins/average_filter_plugin"
+    "master/doc/source/examples/07-python-operators/plugins/"
 )
 
 for file in file_list:
-    EXAMPLE_FILE = GITHUB_SOURCE_URL + "/average_filter_plugin/" + file
-    operator_file_path = examples.downloads._retrieve_file(
-        EXAMPLE_FILE, file, "python_plugins/average_filter_plugin"
-    )
+    EXAMPLE_FILE = GITHUB_SOURCE_URL + file
+    operator_file_path = examples.downloads._retrieve_file(EXAMPLE_FILE, file, "python_plugins")
     plugin_folder = os.path.dirname(operator_file_path)
     print(f"\033[1m {file}:\n \033[0m")
     with open(operator_file_path, "r") as f:

--- a/examples/08-python-operators/01-package_python_operators.py
+++ b/examples/08-python-operators/01-package_python_operators.py
@@ -58,7 +58,6 @@ For this example, the plug-in package contains two different operators:
 import os
 
 from ansys.dpf.core import examples
-from ansys.dpf import core as dpf
 
 
 print("\033[1m average_filter_plugin")

--- a/examples/08-python-operators/02-python_operators_with_dependencies.py
+++ b/examples/08-python-operators/02-python_operators_with_dependencies.py
@@ -60,7 +60,6 @@ file at the given path.
 import os
 
 from ansys.dpf.core import examples
-from ansys.dpf import core as dpf
 
 
 print("\033[1m gltf_plugin")
@@ -73,17 +72,16 @@ file_list = [
     "gltf_plugin/texture.png",
     "gltf_plugin.xml",
 ]
-import os
-
-folder_root = os.path.join(os.getcwd().rsplit("pydpf-core", 1)[0], "pydpf-core")
-source_path_in_repo = r"doc\source\examples\07-python-operators\plugins"
-operator_folder = os.path.join(folder_root, source_path_in_repo)
-print(operator_folder)
 plugin_path = None
+folder_root = os.path.join(os.getcwd().rsplit("pydpf-core", 1)[0], "pydpf-core")
+GITHUB_SOURCE_URL = (
+    "https://github.com/ansys/pydpf-core/raw/"
+    "master/doc/source/examples/07-python-operators/plugins/"
+)
 
 for file in file_list:
-    operator_file_path = os.path.join(operator_folder, file)
-
+    EXAMPLE_FILE = GITHUB_SOURCE_URL + file
+    operator_file_path = examples.downloads._retrieve_file(EXAMPLE_FILE, file, "python_plugins")
     print(f"\033[1m {file}\n \033[0m")
     if (
         os.path.splitext(file)[1] == ".py" or os.path.splitext(file)[1] == ".xml"

--- a/src/ansys/dpf/core/examples/downloads.py
+++ b/src/ansys/dpf/core/examples/downloads.py
@@ -82,7 +82,7 @@ def _retrieve_file(url, filename, directory):
     from ansys.dpf.core import LOCAL_DOWNLOADED_EXAMPLES_PATH
 
     # First check if file has already been downloaded
-    local_path = os.path.join(LOCAL_DOWNLOADED_EXAMPLES_PATH, directory, os.path.basename(filename))
+    local_path = os.path.join(LOCAL_DOWNLOADED_EXAMPLES_PATH, directory, filename)
     local_path_no_zip = local_path.replace(".zip", "")
     if os.path.isfile(local_path_no_zip) or os.path.isdir(local_path_no_zip):
         return local_path_no_zip


### PR DESCRIPTION
Took out the initial branch where python plugins were stored.
Fixing that by actually targeting the master branch, which is better anyway.