### PR TITLE
fix: exclusion of example files causing doc-build failure

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -62,6 +62,7 @@ for example in glob(r"../../examples/**/*.py"):
         ignored_pattern += f"|{example_name}"
 ignored_pattern += "|11-server_types.py"
 ignored_pattern += "|06-distributed_stress_averaging.py"
+ignored_pattern += "|02-python_operators_with_dependencies.py"
 ignored_pattern += r")"
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Certain examples are causing the documentation build process to fail and this is blocking the merging of several other pull requests (see #1952, #1959). It is proposed to temporarily exclude erring examples from documentation generation until there behavior is fixed.