### PR TITLE
Add contact result properties

### DIFF
--- a/src/ansys/dpf/core/available_result.py
+++ b/src/ansys/dpf/core/available_result.py
@@ -313,6 +313,16 @@ _result_properties = {
     "TF": {"location": "ElementalNodal", "scripting_name": "heat_flux"},
     "UTOT": {"location": "Nodal", "scripting_name": "raw_displacement"},
     "RFTOT": {"location": "Nodal", "scripting_name": "raw_reaction_force"},
+    "ECT_STAT": {"location": "ElementalNodal", "scripting_name": "contact_status"},
+    "ECT_PRES": {"location": "ElementalNodal", "scripting_name": "contact_pressure"},
+    "ECT_PENE": {"location": "ElementalNodal", "scripting_name": "contact_penetration"},
+    "ECT_SLIDE": {"location": "ElementalNodal", "scripting_name": "contact_sliding_distance"},
+    "ECT_GAP": {"location": "ElementalNodal", "scripting_name": "contact_gap_distance"},
+    "ECT_SFRIC": {"location": "ElementalNodal", "scripting_name": "contact_friction_stress"},
+    "ECT_STOT": {"location": "ElementalNodal", "scripting_name": "contact_total_stress"},
+    "ECT_FRES": {"location": "ElementalNodal",
+                 "scripting_name": "contact_fluid_penetration_pressure"},
+    "ECT_FLUX": {"location": "ElementalNodal", "scripting_name": "contact_surface_heat_flux"},
 }
 
 

--- a/src/ansys/dpf/core/available_result.py
+++ b/src/ansys/dpf/core/available_result.py
@@ -320,8 +320,10 @@ _result_properties = {
     "ECT_GAP": {"location": "ElementalNodal", "scripting_name": "contact_gap_distance"},
     "ECT_SFRIC": {"location": "ElementalNodal", "scripting_name": "contact_friction_stress"},
     "ECT_STOT": {"location": "ElementalNodal", "scripting_name": "contact_total_stress"},
-    "ECT_FRES": {"location": "ElementalNodal",
-                 "scripting_name": "contact_fluid_penetration_pressure"},
+    "ECT_FRES": {
+        "location": "ElementalNodal",
+        "scripting_name": "contact_fluid_penetration_pressure",
+    },
     "ECT_FLUX": {"location": "ElementalNodal", "scripting_name": "contact_surface_heat_flux"},
 }
 


### PR DESCRIPTION
This is required so that force_elemental_nodal is correctly computed for contact results in pydpf-post. As far as I can see this dictionary is only used to lookup metadata on request and does not impact the available results directly. The scripting name is taken from dataProcessingDoc.html in the dpf core repo.