### PR TITLE
Fix ansys installation finder

### DIFF
--- a/src/ansys/dpf/core/misc.py
+++ b/src/ansys/dpf/core/misc.py
@@ -183,9 +183,9 @@ def find_ansys():
     if base_path is None:
         return base_path
 
-    paths = base_path.glob("v*")
+    paths = list(base_path.glob("v*"))
 
-    if not list(paths):
+    if not paths:
         return None
 
     versions = {}


### PR DESCRIPTION
The changes in [this PR](https://github.com/ansys/pydpf-core/pull/1949) broke the Ansys finder, at least on Linux. See code comments for a description of the changes.

Tested on a Linux machine with Ansys installed at `/ansys_inc/v251` using a minimal script replicating the logic in the function `find_ansys`.

Original script:

```python
import os
from pathlib import Path

def is_float(string):
    try:
        float(string)
        return True
    except ValueError:
        return False

def find_ansys():

    base_path = None
    if os.name == "nt":
        base_path = Path(os.environ["PROGRAMFILES"]) / "ANSYS INC"
    elif os.name == "posix":
        for path in [Path("/usr/ansys_inc"), Path("/ansys_inc")]:
            if path.is_dir():
                base_path = path
    else:
        raise OSError(f"Unsupported OS {os.name}")

    if base_path is None:
        return base_path

    paths = base_path.glob("v*")

    if not list(paths):
        return None

    versions = {}
    for path in paths:
        ver_str = str(path)[-3:]
        if is_float(ver_str):
            versions[int(ver_str)] = str(path)

    return versions[max(versions.keys())]

print(find_ansys())
```

Output:

```python
Traceback (most recent call last):
  File "find_ansys_bug.py", line 39, in <module>
    print(find_ansys())
  File "find_ansys_bug.py", line 37, in find_ansys
    return versions[max(versions.keys())]
ValueError: max() arg is an empty sequence
```

Diff of fixed script (same as this PR):
```diff
--- a/find_ansys_bug.py
+++ b/find_ansys.py
@@ -23,9 +23,9 @@ def find_ansys():
     if base_path is None:
         return base_path

-    paths = base_path.glob("v*")
+    paths = list(base_path.glob("v*"))

-    if not list(paths):
+    if not paths:
         return None
```

Output:
```python 
/ansys_inc/v251
```

> Note: codecov complains about 0% coverage but I'd say that if tests weren't failing before the fix, I have little chance to come up with a good test. 