### PR TITLE
Fix averaging example plots

### DIFF
--- a/examples/09-averaging/00-compute_and_average.py
+++ b/examples/09-averaging/00-compute_and_average.py
@@ -120,7 +120,6 @@ def compute_von_mises_then_average(analysis):
     max_val = min_max.outputs.field_max()
 
     avg_von_mises.plot()
-  
     return max_val.data[0]
 
 

--- a/examples/09-averaging/00-compute_and_average.py
+++ b/examples/09-averaging/00-compute_and_average.py
@@ -98,7 +98,6 @@ analysis = examples.download_crankshaft()
 def compute_von_mises_then_average(analysis):
     # Create a model from the results of the simulation and retrieve its mesh
     model = dpf.Model(analysis)
-    mesh = model.metadata.meshed_region
 
     # Apply the stress operator to obtain the stresses in the body
     stress_op = dpf.operators.result.stress()
@@ -120,6 +119,8 @@ def compute_von_mises_then_average(analysis):
     min_max.inputs.field.connect(avg_von_mises)
     max_val = min_max.outputs.field_max()
 
+    avg_von_mises.plot()
+  
     return max_val.data[0]
 
 
@@ -156,6 +157,8 @@ def average_then_compute_von_mises(analysis):
     min_max = dpf.operators.min_max.min_max()
     min_max.inputs.field.connect(avg_von_mises)
     max_val = min_max.outputs.field_max()
+
+    avg_von_mises.plot()
 
     return max_val.data[0]
 

--- a/examples/09-averaging/00-compute_and_average.py
+++ b/examples/09-averaging/00-compute_and_average.py
@@ -158,7 +158,6 @@ def average_then_compute_von_mises(analysis):
     max_val = min_max.outputs.field_max()
 
     avg_von_mises.plot()
-
     return max_val.data[0]
 
 

--- a/examples/09-averaging/00-compute_and_average.py
+++ b/examples/09-averaging/00-compute_and_average.py
@@ -135,7 +135,6 @@ def compute_von_mises_then_average(analysis):
 def average_then_compute_von_mises(analysis):
     # Creating the model from the results of the simulation
     model = dpf.Model(analysis)
-    mesh = model.metadata.meshed_region
 
     # Retrieving the stresses
     stress_op = dpf.operators.result.stress()


### PR DESCRIPTION
The first example of the averaging section lost its calls to plot methods at some point, not fitting the description anymore. This PR adds them back to fix the example.