### PR TITLE
Fix connecting Any as inpt

### DIFF
--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -832,14 +832,6 @@ class Operator:
             # Type match
             if type(inpt).__name__ == python_name:
                 corresponding_pins.append(pin)
-            # Input accepts Any
-            elif python_name == "Any":
-                corresponding_pins.append(pin)
-            # If any output type matches python_name
-            elif isinstance(inpt, Output):
-                for inpttype in inpt._python_expected_types:
-                    if inpttype == python_name:
-                        corresponding_pins.append(pin)
             # if the inpt has multiple potential outputs, find which ones can match
             elif isinstance(inpt, (_Outputs, Operator, Result)):
                 if isinstance(inpt, Operator):
@@ -850,6 +842,16 @@ class Operator:
                     output_pin_available = inpt._get_given_output([python_name])
                 for outputpin in output_pin_available:
                     corresponding_pins.append((pin, outputpin))
+            # If any output type matches python_name
+            elif isinstance(inpt, Output):
+                if python_name == "Any":
+                    corresponding_pins.append(pin)
+                else:
+                    for inpttype in inpt._python_expected_types:
+                        if inpttype == python_name:
+                            corresponding_pins.append(pin)
+            elif python_name == "Any":
+                corresponding_pins.append(pin)
 
     def __add__(self, fields_b):
         """Add two fields or two fields containers.

--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -829,8 +829,18 @@ class Operator:
             if python_name == "B":
                 python_name = "bool"
 
+            # Type match
             if type(inpt).__name__ == python_name:
                 corresponding_pins.append(pin)
+            # Input accepts Any
+            elif python_name == "Any":
+                corresponding_pins.append(pin)
+            # If any output type matches python_name
+            elif isinstance(inpt, Output):
+                for inpttype in inpt._python_expected_types:
+                    if inpttype == python_name:
+                        corresponding_pins.append(pin)
+            # if the inpt has multiple potential outputs, find which ones can match
             elif isinstance(inpt, (_Outputs, Operator, Result)):
                 if isinstance(inpt, Operator):
                     output_pin_available = inpt.outputs._get_given_output([python_name])
@@ -840,14 +850,6 @@ class Operator:
                     output_pin_available = inpt._get_given_output([python_name])
                 for outputpin in output_pin_available:
                     corresponding_pins.append((pin, outputpin))
-            elif isinstance(inpt, Output):
-                for inpttype in inpt._python_expected_types:
-                    if inpttype == python_name:
-                        corresponding_pins.append(pin)
-                if python_name == "Any":
-                    corresponding_pins.append(pin)
-            elif python_name == "Any":
-                corresponding_pins.append(pin)
 
     def __add__(self, fields_b):
         """Add two fields or two fields containers.

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1496,3 +1496,9 @@ def test_operator_id(server_type):
         assert op.id not in ids
 
         ids.add(op.id)
+
+
+def test_operator_find_outputs_corresponding_pins_any(server_type):
+    f1 = ops.utility.forward()
+    f2 = ops.utility.forward()
+    f2.inputs.any.connect(f1.outputs.any)


### PR DESCRIPTION
Error was raised when doing:
```
from ansys.dpf.core import operators as ops

f1 = ops.utility.forward()
f2 = ops.utility.forward()
f2.inputs.any.connect(f1.outputs.any)
```
Error marked pin connection as ambiguous due to mismanagement of `Any` pin type in `Operator._find_outputs_corresponding_pins`.

The whole `Input.connect` and `Inputs.connect` needs a big refactor.