### PR TITLE
Accept a Python range when setting scoping IDs.

### DIFF
--- a/src/ansys/dpf/core/mesh_scoping_factory.py
+++ b/src/ansys/dpf/core/mesh_scoping_factory.py
@@ -102,7 +102,9 @@ def face_scoping(face_ids: IdVectorType, server: AnyServerType = None) -> Scopin
     return scoping
 
 
-def named_selection_scoping(named_selection_name: str, model: Model) -> Scoping:
+def named_selection_scoping(
+    named_selection_name: str, model: Model, server: AnyServerType = None
+) -> Scoping:
     """Create a :class:`ansys.dpf.core.Scoping` based on a named selection in a model.
 
     Parameters

--- a/src/ansys/dpf/core/mesh_scoping_factory.py
+++ b/src/ansys/dpf/core/mesh_scoping_factory.py
@@ -23,87 +23,99 @@
 """
 mesh_scoping_factory.
 
-Contains functions to simplify creating mesh scopings.
+Contains functions to simplify creating a mesh scoping.
 """
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: nocover
+    from ansys.dpf.core.server_types import AnyServerType
+    from ansys.dpf.core.scoping import IdVectorType
+    from ansys.dpf.core.model import Model
 
 from ansys.dpf.core import Scoping
 from ansys.dpf.core.common import locations
 
 
-def nodal_scoping(node_ids, server=None):
-    """Create a specific nodal :class:`ansys.dpf.core.Scoping` associated with a mesh.
+def nodal_scoping(node_ids: IdVectorType, server: AnyServerType = None) -> Scoping:
+    """Create a nodal :class:`ansys.dpf.core.Scoping` defining a list of node IDs.
 
     Parameters
     ----------
-    node_ids : list[int]
-        List of IDs for the nodes.
-    server : DpfServer, optional
+    node_ids:
+        List of node IDs.
+    server:
         Server with the channel connected to the remote or local instance.
         The default is ``None``, in which case an attempt is made to use the
         global server.
 
     Returns
     -------
-    scoping : Scoping
+    scoping:
+        A nodal scoping containing the node IDs provided.
     """
     scoping = Scoping(server=server, ids=node_ids, location=locations.nodal)
     return scoping
 
 
-def elemental_scoping(element_ids, server=None):
-    """Create a specific elemental :class:`ansys.dpf.core.Scoping` associated with a mesh.
+def elemental_scoping(element_ids: IdVectorType, server: AnyServerType = None) -> Scoping:
+    """Create an elemental :class:`ansys.dpf.core.Scoping` defining a list of element IDs.
 
     Parameters
     ----------
-    element_ids : list[int]
-        List of IDs for the elements.
-    server : DpfServer, optional
+    element_ids:
+        List of element IDs.
+    server:
         Server with the channel connected to the remote or local instance.
         The default is ``None``, in which case an attempt is made to use the
         global server.
 
     Returns
     -------
-    scoping : Scoping
+    scoping:
+        An elemental scoping containing the element IDs provided.
     """
     scoping = Scoping(server=server, ids=element_ids, location=locations.elemental)
     return scoping
 
 
-def face_scoping(face_ids, server=None):
-    """Create a specific face :class:`ansys.dpf.core.Scoping` associated with a mesh.
+def face_scoping(face_ids: IdVectorType, server: AnyServerType = None) -> Scoping:
+    """Create a face :class:`ansys.dpf.core.Scoping`defining a list of face IDs.
 
     Parameters
     ----------
-    face_ids : list[int]
-        List of IDs for the faces.
-    server : DpfServer, optional
+    face_ids:
+        List of face IDs.
+    server:
         Server with the channel connected to the remote or local instance.
         The default is ``None``, in which case an attempt is made to use the
         global server.
 
     Returns
     -------
-    scoping : Scoping
+    scoping:
+        A face scoping containing the face IDs provided.
     """
     scoping = Scoping(server=server, ids=face_ids, location=locations.faces)
     return scoping
 
 
-def named_selection_scoping(named_selection_name, model, server=None):
-    """Create a specific :class:`ansys.dpf.core.Scoping` associated with a specified model's mesh.
+def named_selection_scoping(named_selection_name: str, model: Model) -> Scoping:
+    """Create a :class:`ansys.dpf.core.Scoping` based on a named selection in a model.
 
     Parameters
     ----------
-    named_selection_name : str
+    named_selection_name:
         Name of the named selection.
-    server : DpfServer, optional
-        Server with the channel connected to the remote or local instance.
-        The default is ``None``, in which case an attempt is made to use the
-        global server.
+    model:
+        Model where the named selection exists.
 
     Returns
     -------
-    scoping : Scoping
+    scoping:
+        A scoping containing the IDs of the entities in the named selection.
+        The location depends on the type of entities targeted by the named selection.
     """
     return model.metadata.named_selection(named_selection_name)

--- a/src/ansys/dpf/core/scoping.py
+++ b/src/ansys/dpf/core/scoping.py
@@ -43,7 +43,6 @@ from ansys.dpf.gate import (
     dpf_vector_capi,
     dpf_vector_abstract_api,
     dpf_vector,
-    dpf_array,
     utils,
 )
 from ansys.dpf.gate.dpf_array import DPFArray
@@ -232,10 +231,26 @@ class Scoping:
             self._api.scoping_get_ids_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size
             )
-            return dpf_array.DPFArray(vec) if np_array else vec.np_array.tolist()
+            return DPFArray(vec) if np_array else vec.np_array.tolist()
 
         except NotImplementedError:
             return self._api.scoping_get_ids(self, np_array)
+
+    def get_ids(self, np_array: bool = False) -> Union[list[int], DPFArray]:
+        """Return the list of entity IDs in the scoping as a list or as a numpy.ndarray.
+
+        Parameters
+        ----------
+        np_array:
+            Whether to return the list of IDs as a numpy array.
+
+        Returns
+        -------
+        ids:
+            List of entity IDs in the scoping.
+
+        """
+        return self._get_ids(np_array=np_array)
 
     def set_id(self, index: int, scopingid: int):
         """Set the ID of the entity at index in the scoping.
@@ -313,17 +328,18 @@ class Scoping:
 
     @property
     def ids(self) -> Union[DPFArray, list[int]]:
-        """Retrieve a list of IDs in the scoping.
+        """Retrieve the entity IDs in the scoping.
 
         Returns
         -------
-        ids : DPFArray, list of int
-            List of IDs to retrieve. By default, a mutable DPFArray is returned.
+        ids:
+            List of IDs in the scoping.
+            By default, a mutable DPFArray is returned.
             To change the return type to a list for the complete python session, see
             :func:`ansys.dpf.core.settings.get_runtime_client_config` and
             :func:`ansys.dpf.core.runtime_config.RuntimeClientConfig.return_arrays`.
-            To change the return type to a list once, use
-            :func:`ansys.dpf.core.scoping.Scoping._get_ids` with the parameter ``np_array=False``.
+            To get the list of IDs from a scoping as a Python list without changing a default
+            configuration, use :func:`ansys.dpf.core.scoping.Scoping.get_ids` instead.
 
         """
         return self._get_ids()

--- a/src/ansys/dpf/core/scoping.py
+++ b/src/ansys/dpf/core/scoping.py
@@ -336,7 +336,7 @@ class Scoping:
     def location(self) -> str:
         """Location of the scoping as a string.
 
-        This defines the type of entity the IDs stored correspond to.
+        This defines the type of entity the IDs correspond to (such as node ID, element ID, face ID, and so on).
 
         Returns
         -------

--- a/src/ansys/dpf/core/scoping.py
+++ b/src/ansys/dpf/core/scoping.py
@@ -189,9 +189,6 @@ class Scoping:
         ids:
             Entity IDs to set.
 
-        Notes
-        -----
-        Prints a progress bar.  # TODO: still true?
         """
         if isinstance(ids, range):
             ids = list(ids)
@@ -328,9 +325,6 @@ class Scoping:
             To change the return type to a list once, use
             :func:`ansys.dpf.core.scoping.Scoping._get_ids` with the parameter ``np_array=False``.
 
-        Notes
-        -----
-        Prints a progress bar.  # TODO is that true?
         """
         return self._get_ids()
 

--- a/src/ansys/dpf/core/scoping.py
+++ b/src/ansys/dpf/core/scoping.py
@@ -62,7 +62,7 @@ class Scoping:
     Parameters
     ----------
     scoping:
-        Grpc message or pointer for an existing Scoping on the server.
+        gRPC message or pointer for an existing scoping on the server.
     server:
         Server with channel connected to the remote or local instance.
         The default is ``None``, in which case an attempt is made to use the
@@ -399,7 +399,7 @@ class Scoping:
         Returns
         -------
         size:
-            Size if the scoping.
+            Size of the scoping.
 
         """
         return self._count()

--- a/src/ansys/dpf/core/scoping.py
+++ b/src/ansys/dpf/core/scoping.py
@@ -90,6 +90,12 @@ class Scoping:
     >>> my_elemental_scoping = dpf.Scoping(location=dpf.locations.elemental, ids=[2, 7, 11])
     >>> # b. scoping with nodal  location that targets the elements with id 4 to 6
     >>> my_nodal_scoping = dpf.Scoping(ids=range(4, 7))
+    >>> # 3. create a time_freq scoping that targets the second load step
+    >>> from ansys.dpf.core import time_freq_scoping_factory
+    >>> # a. using the time_freq_scoping_factory
+    >>> my_load_step_scoping = time_freq_scoping_factory.scoping_by_load_step(2)
+    >>> # b. using the Scoping class directly
+    >>> my_load_step_scoping = dpf.Scoping(location=dpf.locations.time_freq_step, ids=[2])
 
     """
 

--- a/src/ansys/dpf/core/scoping.py
+++ b/src/ansys/dpf/core/scoping.py
@@ -139,8 +139,6 @@ class Scoping:
 
         # step5: handle specific calls to set attributes
         if ids is not None:
-            if isinstance(ids, range):
-                ids = list(ids)
             self.ids = ids
         if location is not None:
             self.location = location

--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -1496,3 +1496,5 @@ class LegacyGrpcServer(BaseServer):
 # DpfServer: TypeAlias = LegacyGrpcServer
 # Python <3.10
 DpfServer = LegacyGrpcServer
+
+AnyServerType = Union[LegacyGrpcServer, InProcessServer, GrpcServer]

--- a/tests/test_scoping.py
+++ b/tests/test_scoping.py
@@ -102,10 +102,10 @@ def test_get_ids_return_type_scoping(server_type):
     client_config.return_arrays = return_arrays_init
     assert np.allclose(scop.ids, ids)
     assert isinstance(scop.ids, np.ndarray)
-    assert np.allclose(scop._get_ids(True), ids)
-    assert isinstance(scop._get_ids(True), np.ndarray)
-    assert np.allclose(scop._get_ids(False), ids)
-    assert isinstance(scop._get_ids(False), list)
+    assert np.allclose(scop.get_ids(True), ids)
+    assert isinstance(scop.get_ids(True), np.ndarray)
+    assert np.allclose(scop.get_ids(False), ids)
+    assert isinstance(scop.get_ids(False), list)
 
 
 def test_get_location_scoping():

--- a/tests/test_scoping.py
+++ b/tests/test_scoping.py
@@ -64,6 +64,18 @@ def test_set_get_ids_scoping(server_type):
     assert np.allclose(scop.ids, ids)
 
 
+def test_set_get_ids_scoping_range(server_type):
+    range_ids = range(1, 10)
+    scop = Scoping(
+        ids=range_ids,
+        server=server_type,
+    )
+    assert np.allclose(scop.ids, range_ids)
+    scop = Scoping(server=server_type)
+    scop.ids = range_ids
+    assert np.allclose(scop.ids, range_ids)
+
+
 @pytest.mark.skipif(
     not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_2_0,
     reason="Requires server version higher than 2.0",


### PR DESCRIPTION
Hi @JennaPaikowsky, the PR for the field inspired me to do this for the `Scoping` class as I noticed we were doing `list(range(*))` in the docstring examples for the `Field` when defining a `Scoping`.

This PR mainly adds the support for a range as input when setting the IDs of a scoping.

It also adds type hinting and improves the docstrings a bit. I'll also add some docstring examples and testing.

I'll actually add the `AnyServerType` type for type hint in a dedicated PR if @moe-ad and @jorgepiloto confirm this is the correct way to provide a combination of allowed types for type hints in the rest of the library. See #2002 

@jorgepiloto @moe-ad one thing I would like our opinion on is the type hint for pointers and Grpc messages as I think it will not work as-is. Edit: it looks like it does! Even though the IDE is complaining that `ansys.grpc.dpf.scoping_pb2.Scoping` does not exist.