### PR TITLE
Add maximum number of failures in PyDPF-Post test CI

### DIFF
--- a/.github/workflows/pydpf-post.yml
+++ b/.github/workflows/pydpf-post.yml
@@ -159,7 +159,7 @@ jobs:
         shell: bash
         working-directory: pydpf-post/tests
         run: |
-          pytest $DEBUG --reruns 2 .
+          pytest $DEBUG --maxfail=5 --reruns 2 .
         if: always()
         timeout-minutes: 60
 


### PR DESCRIPTION
Due to hanging pipelines when tests start failing on Windows for pydpf-post, add a maxfail to the pytest call.
See for example this run https://github.com/ansys/pydpf-core/actions/runs/12711515295/job/35435017936?pr=2002