### PR TITLE
Fix mesh_scoping_factory.named_selection_scoping server argument

### DIFF
--- a/src/ansys/dpf/core/mesh_scoping_factory.py
+++ b/src/ansys/dpf/core/mesh_scoping_factory.py
@@ -106,4 +106,4 @@ def named_selection_scoping(named_selection_name, model, server=None):
     -------
     scoping : Scoping
     """
-    return model.metadata.named_selection(named_selection_name)
+    return model.metadata.named_selection(named_selection=named_selection_name, server=server)

--- a/src/ansys/dpf/core/meshed_region.py
+++ b/src/ansys/dpf/core/meshed_region.py
@@ -406,7 +406,6 @@ class MeshedRegion:
             A scoping containing the IDs of the entities in the named selection.
             The location depends on the type of entities targeted by the named selection.
         """
-        out_scoping = None
         if server_meet_version("2.1", self._server):
             out = self._api.meshed_region_get_named_selection_scoping(self, named_selection)
             out_scoping = scoping.Scoping(scoping=out, server=server)
@@ -427,6 +426,7 @@ class MeshedRegion:
         if server:
             # Copy the scoping to another server
             out_scoping.deep_copy(server=server)
+        return out_scoping
 
     @version_requires("3.0")
     def set_named_selection_scoping(self, named_selection_name, scoping):

--- a/src/ansys/dpf/core/meshed_region.py
+++ b/src/ansys/dpf/core/meshed_region.py
@@ -408,7 +408,7 @@ class MeshedRegion:
         """
         if server_meet_version("2.1", self._server):
             out = self._api.meshed_region_get_named_selection_scoping(self, named_selection)
-            out_scoping = scoping.Scoping(scoping=out, server=server)
+            out_scoping = scoping.Scoping(scoping=out, server=self._server)
         else:
             if hasattr(self, "_stream_provider"):
                 from ansys.dpf.core.dpf_operator import Operator

--- a/src/ansys/dpf/core/meshed_region.py
+++ b/src/ansys/dpf/core/meshed_region.py
@@ -425,7 +425,7 @@ class MeshedRegion:
                 )
         if server:
             # Copy the scoping to another server
-            out_scoping.deep_copy(server=server)
+            out_scoping = out_scoping.deep_copy(server=server)
         return out_scoping
 
     @version_requires("3.0")

--- a/src/ansys/dpf/core/meshed_region.py
+++ b/src/ansys/dpf/core/meshed_region.py
@@ -22,6 +22,14 @@
 
 """MeshedRegion."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: nocover
+    from ansys.dpf.core.server_types import AnyServerType
+    from ansys.dpf.core.scoping import Scoping
+
 import traceback
 import warnings
 
@@ -378,22 +386,30 @@ class MeshedRegion:
             named_selections.append(self._api.meshed_region_get_named_selection_name(self, index))
         return named_selections
 
-    def named_selection(self, named_selection):
-        """
-        Scoping containing the list of nodes or elements in the named selection.
+    def named_selection(
+        self,
+        named_selection: str,
+        server: AnyServerType = None,
+    ) -> Scoping:
+        """Scoping containing the list of nodes or elements in the named selection.
 
         Parameters
         ----------
-        named_selection : str
+        named_selection:
             Name of the named selection.
+        server:
+            Server on which to create the scoping if different from the server of the model.
 
         Returns
         -------
-        named_selection : Scoping
+        named_selection:
+            A scoping containing the IDs of the entities in the named selection.
+            The location depends on the type of entities targeted by the named selection.
         """
+        out_scoping = None
         if server_meet_version("2.1", self._server):
             out = self._api.meshed_region_get_named_selection_scoping(self, named_selection)
-            return scoping.Scoping(scoping=out, server=self._server)
+            out_scoping = scoping.Scoping(scoping=out, server=server)
         else:
             if hasattr(self, "_stream_provider"):
                 from ansys.dpf.core.dpf_operator import Operator
@@ -401,13 +417,16 @@ class MeshedRegion:
                 op = Operator("scoping_provider_by_ns", server=self._server)
                 op.connect(1, named_selection)
                 op.connect(3, self._stream_provider, 0)
-                return op.get_output(0, types.scoping)
+                out_scoping = op.get_output(0, types.scoping)
             else:
                 raise Exception(
                     "Getting a named selection from a meshed region is "
                     "only implemented for meshed region created from a "
                     "model for server version 2.0. Please update your server."
                 )
+        if server:
+            # Copy the scoping to another server
+            out_scoping.deep_copy(server=server)
 
     @version_requires("3.0")
     def set_named_selection_scoping(self, named_selection_name, scoping):

--- a/src/ansys/dpf/core/model.py
+++ b/src/ansys/dpf/core/model.py
@@ -27,6 +27,14 @@ Module contains the Model class to manage file result models.
 
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: nocover
+    from ansys.dpf.core.server_types import AnyServerType
+    from ansys.dpf.core.scoping import Scoping
+
 from ansys import dpf
 from ansys.dpf.core import Operator
 from ansys.dpf.core.common import types
@@ -587,19 +595,23 @@ class Metadata:
         """
         return self.meshed_region.available_named_selections
 
-    def named_selection(self, named_selection):
+    def named_selection(self, named_selection: str, server: AnyServerType = None) -> Scoping:
         """Scoping containing the list of nodes or elements in the named selection.
 
         Parameters
         ----------
-        named_selection : str
-            name of the named selection
+        named_selection:
+            Name of the named selection.
+        server:
+            Server on which to create the scoping if different from the server of the model.
 
         Returns
         -------
-        named_selection : :class:`ansys.dpf.core.scoping.Scoping`
+        named_selection:
+            A scoping containing the IDs of the entities in the named selection.
+            The location depends on the type of entities targeted by the named selection.
         """
-        return self.meshed_region.named_selection(named_selection)
+        return self.meshed_region.named_selection(named_selection=named_selection, server=server)
 
     def _build_connector(self):
         return DataSourcesOrStreamsConnector(self)

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -32,7 +32,6 @@ from ansys.dpf.core import server
 from ansys.dpf.core import server_factory
 from ansys.dpf.core import time_freq_scoping_factory
 from ansys.dpf.core.common import locations
-from conftest import server_type
 
 
 def test_create_matrix_field():

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -28,8 +28,11 @@ from ansys.dpf.core import errors as dpf_errors
 from ansys.dpf.core import fields_container_factory
 from ansys.dpf.core import fields_factory
 from ansys.dpf.core import mesh_scoping_factory
+from ansys.dpf.core import server
+from ansys.dpf.core import server_factory
 from ansys.dpf.core import time_freq_scoping_factory
 from ansys.dpf.core.common import locations
+from conftest import server_type
 
 
 def test_create_matrix_field():
@@ -297,3 +300,12 @@ def test_named_selection_scoping(model_with_ns):
     scop = mesh_scoping_factory.named_selection_scoping("SELECTION", model)
     assert scop is not None
     assert len(scop.ids) != 0
+
+
+def test_named_selection_scoping_with_deepcopy(model_with_ns):
+    model = Model(model_with_ns)
+    server_2 = server.start_local_server(config=server_factory.AvailableServerConfigs.GrpcServer)
+    scop = mesh_scoping_factory.named_selection_scoping("SELECTION", model, server_2)
+    assert scop is not None
+    assert len(scop.ids) != 0
+    assert scop._server == server_2


### PR DESCRIPTION
The `server` argument of the `mesh_scoping_factory.named_selection_scoping` method had no effect.
This PR adds a deep copy of the resulting scoping to the provided server if given one.
The scoping in output is thus on the provided server.