### PR TITLE
Deprecate pkg_resources usage

### DIFF
--- a/src/ansys/dpf/core/__init__.py
+++ b/src/ansys/dpf/core/__init__.py
@@ -1,5 +1,4 @@
 import os
-import pkg_resources
 
 try:
     import importlib.metadata as importlib_metadata
@@ -25,7 +24,7 @@ try:
 except:  # pragma: no cover
     pass
 
-installed = [d.project_name for d in pkg_resources.working_set]
+installed = [d.metadata["Name"] for d in importlib_metadata.distributions()]
 check_for = ["ansys-dpf-gatebin", "ansys-dpf-gate", "ansys-grpc-dpf"]
 if any([c in installed for c in check_for]):
     raise ImportError(f"Error during import of ansys-dpf-core:\n"

--- a/src/ansys/dpf/gate/load_api.py
+++ b/src/ansys/dpf/gate/load_api.py
@@ -85,7 +85,6 @@ def _paths_to_dpf_server_library_installs() -> dict:
     for d in importlib_metadata.distributions():
         distribution_name = d.metadata["Name"]
         if "ansys-dpf-server" in distribution_name:
-            print(distribution_name)
             # Cannot use the distribution.files() as those only list the files in the site-packages,
             # which for editable installations does not necessarily give the actual location of the
             # source files. It may rely on a Finder, which has to run.

--- a/src/ansys/dpf/gate/load_api.py
+++ b/src/ansys/dpf/gate/load_api.py
@@ -85,6 +85,7 @@ def _paths_to_dpf_server_library_installs() -> dict:
     for d in importlib_metadata.distributions():
         distribution_name = d.metadata["Name"]
         if "ansys-dpf-server" in distribution_name:
+            print(distribution_name)
             # Cannot use the distribution.files() as those only list the files in the site-packages,
             # which for editable installations does not necessarily give the actual location of the
             # source files. It may rely on a Finder, which has to run.
@@ -96,7 +97,7 @@ def _paths_to_dpf_server_library_installs() -> dict:
                     sys.executable,
                     "-c",
                     f"""import importlib 
-print(importlib.import_module('{distribution_name}'.replace('-', '.')).__path__[0])""",
+print(importlib.import_module('ansys.dpf.server{distribution_name[16:]}'.replace('-', '_')).__path__[0])""",
                 ],
                 text=True,
             ).rstrip()

--- a/src/ansys/dpf/gate/load_api.py
+++ b/src/ansys/dpf/gate/load_api.py
@@ -1,15 +1,12 @@
 import os
 import subprocess
 import sys
-from pathlib import Path
 
 import packaging.version
-import importlib
 try:
     import importlib.metadata as importlib_metadata
 except ImportError:  # Python < 3.10 (backport)
     import importlib_metadata as importlib_metadata
-import importlib
 from ansys.dpf.gate.generated import capi
 from ansys.dpf.gate import utils, errors
 from ansys.dpf.gate._version import __ansys_version__
@@ -91,7 +88,7 @@ def _paths_to_dpf_server_library_installs() -> dict:
             # The most robust way of resolving the location is to let the import machinery do its
             # job, using importlib.import_module. We do not want however to actually import the
             # server libraries found, which is why we do it in a subprocess.
-            package_path = subprocess.check_output(
+            package_path = subprocess.check_output(  # nosec B603
                 args=[
                     sys.executable,
                     "-c",

--- a/src/ansys/dpf/gate/load_api.py
+++ b/src/ansys/dpf/gate/load_api.py
@@ -1,5 +1,5 @@
 import os
-import subprocess
+import subprocess  # nosec B404
 import sys
 
 import packaging.version


### PR DESCRIPTION
The `pkg_resources` library is marked as deprecated and raises warnings.
We switch to using `importlib`.
This is done is two places:
- in the `ansys.dpf.core.__init__.py` to check the presence of `ansys-dpf-gate`, `ansys-dpf-gatebin` or `ansys-grpc-dpf` in the Python environment and raise a deprecation error.
- in `ansys.dpf.gate.load_api.__paths_to_dpf_server_library_installs` to detect installed `ansys-dpf-server***` libraries and return install paths.