### PR TITLE
Fix server_to_ansys_version

### DIFF
--- a/src/ansys/dpf/core/_version.py
+++ b/src/ansys/dpf/core/_version.py
@@ -31,18 +31,14 @@ min_server_version = "4.0"
 class ServerToAnsysVersion:
     def __getitem__(self, item):
         version = parse_version(item)
-        if version.major < 2024:
-            # Support the current DPF versioning scheme (XX.Y where necessarily XX<2024)
-            # Compute release version equivalent (YEAR+'R'+REVISION)
-            # The revision is 'R1' for any odd major DPF version, 'R2' for even major versions.
-            ansys_revision = 2 - version.major % 2
-            # The year is 2021 for DPF 1.0, and bumped every two releases.
-            ansys_year = 2020 + version.major // 2 + version.major % 2
-            # Return the corresponding Ansys release
-            return f"{ansys_year}R{ansys_revision}"
-        else:
-            # Support the YEAR.REVISION versioning scheme for DPF
-            return f"{version.major}R{version.minor}"
+        # The current DPF versioning scheme is MAJOR.MINOR.PATCH
+        # Compute release version equivalent (YEAR+'R'+REVISION)
+        # The revision is 'R1' for any odd major DPF version, 'R2' for even major versions.
+        ansys_revision = 2 - version.major % 2
+        # The year is 2021 for DPF 1.0, and bumped every two releases.
+        ansys_year = 2020 + version.major // 2 + version.major % 2
+        # Return the corresponding Ansys release
+        return f"{ansys_year}R{ansys_revision}"
 
 
 server_to_ansys_version = ServerToAnsysVersion()

--- a/src/ansys/dpf/core/_version.py
+++ b/src/ansys/dpf/core/_version.py
@@ -27,31 +27,16 @@ min_server_version = "4.0"
 
 
 class ServerToAnsysVersion:
-    legacy_version_map = {
-        "1.0": "2021R1",
-        "2.0": "2021R2",
-        "3.0": "2022R1",
-        "4.0": "2022R2",
-        "5.0": "2023R1",
-        "6.0": "2023R2",
-        "6.1": "2023R2",
-        "6.2": "2023R2",
-        "7.0": "2024R1",
-        "7.1": "2024R1",
-        "8.0": "2024R2",
-        "8.1": "2024R2",
-        "8.2": "2024R2",
-        "9.0": "2025R1",
-        "9.1": "2025R1",
-        "10.0": "2025R2",
-    }
-
     def __getitem__(self, item):
-        if len(item) == 3:
-            return self.legacy_version_map[item]
-        else:
-            split = item.split(".")
-            return split[0] + "R" + split[1]
+        split = item.split(".")
+        major = int(split[0])
+        minor = int(split[1])
+        if major < 2024:
+            # Detect new cases of XX.Y versions (necessarily XX<2024)
+            # Compute release version equivalent
+            minor = 2 - major % 2
+            major = 2020 + major // 2 + major % 2
+        return f"{major}R{minor}"
 
 
 server_to_ansys_version = ServerToAnsysVersion()

--- a/src/ansys/dpf/core/_version.py
+++ b/src/ansys/dpf/core/_version.py
@@ -22,21 +22,27 @@
 
 """Version for ansys-dpf-core."""
 
+from packaging.version import parse as parse_version
+
 # Minimal DPF server version supported
 min_server_version = "4.0"
 
 
 class ServerToAnsysVersion:
     def __getitem__(self, item):
-        split = item.split(".")
-        major = int(split[0])
-        minor = int(split[1])
-        if major < 2024:
-            # Detect new cases of XX.Y versions (necessarily XX<2024)
-            # Compute release version equivalent
-            minor = 2 - major % 2
-            major = 2020 + major // 2 + major % 2
-        return f"{major}R{minor}"
+        version = parse_version(item)
+        if version.major < 2024:
+            # Support the current DPF versioning scheme (XX.Y where necessarily XX<2024)
+            # Compute release version equivalent (YEAR+'R'+REVISION)
+            # The revision is 'R1' for any odd major DPF version, 'R2' for even major versions.
+            ansys_revision = 2 - version.major % 2
+            # The year is 2021 for DPF 1.0, and bumped every two releases.
+            ansys_year = 2020 + version.major // 2 + version.major % 2
+            # Return the corresponding Ansys release
+            return f"{ansys_year}R{ansys_revision}"
+        else:
+            # Support the YEAR.REVISION versioning scheme for DPF
+            return f"{version.major}R{version.minor}"
 
 
 server_to_ansys_version = ServerToAnsysVersion()

--- a/tests/test_checkversion.py
+++ b/tests/test_checkversion.py
@@ -112,4 +112,4 @@ def test_version():
     from ansys.dpf.core._version import server_to_ansys_version
 
     assert server_to_ansys_version["1.0"] == "2021R1"
-    assert server_to_ansys_version["2099.9"] == "2099R9"
+    assert server_to_ansys_version["10.0.12"] == "2025R2"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -35,10 +35,6 @@ from ansys.dpf.core._version import server_to_ansys_version
         ("3.0", "2022R1"),
         ("2023.0", "3032R1"),
         ("2023.1.12", "3032R1"),
-        # Proposed calendar-like versioning
-        ("2024.0", "2024R0"),
-        ("2024.1.12", "2024R1"),
-        ("2024.1.pre0", "2024R1"),
     ],
 )
 def test_server_to_ansys_version(server_version, ansys_version):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -28,14 +28,16 @@ from ansys.dpf.core._version import server_to_ansys_version
 @pytest.mark.parametrize(
     "server_version,ansys_version",
     [
+        # Current DPF versioning
         ("1.0", "2021R1"),
         ("2.0", "2021R2"),
         ("2.1", "2021R2"),
         ("3.0", "2022R1"),
         ("2023.0", "3032R1"),
         ("2023.1.12", "3032R1"),
+        # Proposed calendar-like versioning
         ("2024.0", "2024R0"),
-        ("2024.1", "2024R1"),
+        ("2024.1.12", "2024R1"),
         ("2024.1.pre0", "2024R1"),
     ],
 )

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2020 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+
+from ansys.dpf.core._version import server_to_ansys_version
+
+
+@pytest.mark.parametrize(
+    "server_version,ansys_version",
+    [
+        ("1.0", "2021R1"),
+        ("2.0", "2021R2"),
+        ("2.1", "2021R2"),
+        ("3.0", "2022R1"),
+        ("2023.0", "3032R1"),
+        ("2023.1.12", "3032R1"),
+        ("2024.0", "2024R0"),
+        ("2024.1", "2024R1"),
+        ("2024.1.pre0", "2024R1"),
+    ],
+)
+def test_server_to_ansys_version(server_version, ansys_version):
+    assert server_to_ansys_version[server_version] == ansys_version


### PR DESCRIPTION
Realized the current implementation of the `ServerToAnsysVersion` map would not give the right answer for `10.0` (it gives `10R0`).
Fixed this and refactored to not need to update this version map anymore for each new version.

The only requirement is for DPF to continue only bumping major for new Ansys releases.