### PR TITLE
Create Markdown Operator Docs

### DIFF
--- a/.ci/generate_operators_doc.py
+++ b/.ci/generate_operators_doc.py
@@ -128,12 +128,10 @@ def main():
     server = initialize_server(args.ansys_path)
     if desired_plugin is None:
         operators = available_operator_names(server)
-        for operator_name in operators:
-            generate_operator_doc(server, operator_name, args.include_private)
     else:
-        plugin_operators = get_plugin_operators(server, desired_plugin)
-        for operator_name in plugin_operators:
-            generate_operator_doc(server, operator_name, args.include_private)
+        operators = get_plugin_operators(server, desired_plugin)
+    for operator_name in operators:
+        generate_operator_doc(server, operator_name, args.include_private)
 
 if __name__ == "__main__":
     main()

--- a/.ci/generate_operators_doc.py
+++ b/.ci/generate_operators_doc.py
@@ -2,7 +2,6 @@ from ansys.dpf import core as dpf
 from ansys.dpf.core.dpf_operator import available_operator_names
 from ansys.dpf.core.core import load_library
 import argparse
-import json
 import os
 from jinja2 import Template
 
@@ -55,15 +54,31 @@ def fetch_doc_info(server, operator_name):
         plugin = properties["plugin"]
     else:
         plugin = "N/A"
+    try:
+        scripting_name = properties['scripting_name']
+        full_name = properties['category'] + "." + properties['scripting_name']
+    except KeyError:
+        scripting_name = None
+        full_name = None
+    try:
+        user_name = properties['user_name']
+    except KeyError:
+        user_name = operator_name
+    try:
+        category = properties['category']
+        op_friendly_name = category + ": " + user_name
+    except KeyError:
+        category = ""
+        op_friendly_name = user_name
     scripting_info = {
-        "category": properties['category'],
+        "category": category,
         "plugin": plugin,
-        "scripting_name": properties['scripting_name'],
-        "full_name": properties['category'] + "." + properties['scripting_name'],
-        "internal_name": properties['scripting_name'],
+        "scripting_name": scripting_name,
+        "full_name": full_name,
+        "internal_name": scripting_name,
     }
     return {
-        "operator_name": scripting_info['category'] + ": " + properties['user_name'],
+        "operator_name": op_friendly_name,
         "operator_description": spec.description,
         "inputs": input_info,
         "outputs": output_info,

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,10 @@ instance/
 # Sphinx documentation
 doc/_build/
 
+# Operators documentation
+doc/source/operators_doc/*.md
+!doc/source/operators_doc/operator_doc_template.md
+
 # PyBuilder
 .pybuilder/
 target/

--- a/doc/source/operators_doc/operator_doc_template.md
+++ b/doc/source/operators_doc/operator_doc_template.md
@@ -1,0 +1,31 @@
+# {{ operator_name }}
+
+## Description
+
+{{ operator_description }}
+
+## Inputs
+
+{% for input in inputs %}
+- **Pin {{ input.pin_number }}** {{ input.name }} (type: {{ input.types }}) (optional: {{ input.optional }}): {{ input.document }}
+{% endfor %}
+
+## Outputs
+
+{% for output in outputs %}
+- **Pin {{ output.pin_number }}** {{ output.name }} (type: {{ output.types }}): {{ output.document }}
+{% endfor %}
+
+## Configurations
+
+{% for configuration in configurations %}
+- **{{ configuration.name }}** (type: {{ configuration.types }}) (default: {{ configuration.default_value }}): {{ configuration.document }}
+{% endfor %}
+
+## Scripting
+
+- **category**: {{ scripting_info.category }}
+- **plugin**: {{ scripting_info.plugin }}
+- **scripting name**: {{ scripting_info.scripting_name }}
+- **full name**: {{ scripting_info.full_name }}
+- **internal name**: {{ scripting_info.internal_name }}

--- a/doc/source/operators_doc/operator_doc_template.md
+++ b/doc/source/operators_doc/operator_doc_template.md
@@ -29,3 +29,4 @@
 - **scripting name**: {{ scripting_info.scripting_name }}
 - **full name**: {{ scripting_info.full_name }}
 - **internal name**: {{ scripting_info.internal_name }}
+- **license**: {{ scripting_info.license }}


### PR DESCRIPTION
- Add script `.ci/generate_operators_doc.py` and template `doc/source/operators_doc/operator_doc_template.md`
- Script makes requests to DPF local server for available operators, and generates the same documentation found on https://dpf.docs.pyansys.com/version/stable/operator_reference.html in Markdown format
- Background in: https://github.com/ansys-internal/empowerment/issues/615