### PR TITLE
Bump tests to DPF 2025.1.0 in ci_release.yml

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -15,7 +15,7 @@ on:
       standalone_branch_suffix:
         description: 'Suffix of the branch on standalone'
         required: false
-        default: '.pre0'
+        default: ''
 
 #┌───────────── minute (0 - 59)
 #│ ┌───────────── hour (0 - 23)
@@ -80,7 +80,7 @@ jobs:
       python_versions: '["3.9"]'
       wheel: true
       wheelhouse: true
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
     secrets: inherit
 
   tests:
@@ -91,7 +91,7 @@ jobs:
       DOCSTRING: false
       wheel: false
       wheelhouse: true
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
     secrets: inherit
 
   tests_any_3_9:
@@ -101,7 +101,7 @@ jobs:
       python_versions: '["3.9"]'
       wheel: true
       wheelhouse: false
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       test_any: true
     secrets: inherit
 
@@ -113,7 +113,7 @@ jobs:
       DOCSTRING: false
       wheel: false
       wheelhouse: false
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       test_any: true
     secrets: inherit
 
@@ -121,7 +121,7 @@ jobs:
     uses: ./.github/workflows/docs.yml
     with:
       ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '251' }}
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       event_name: ${{ github.event_name }}
     secrets: inherit
 
@@ -130,7 +130,7 @@ jobs:
     with:
       ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '251' }}
       python_versions: '["3.9", "3.10", "3.11"]'
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
     secrets: inherit
 
   retro_242:
@@ -184,7 +184,7 @@ jobs:
     uses: ./.github/workflows/pydpf-post.yml
     with:
       ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '251' }}
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
       test_docstrings: "true"
     secrets: inherit
 
@@ -228,7 +228,7 @@ jobs:
     uses: ./.github/workflows/test_docker.yml
     with:
       ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '251' }}
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
     secrets: inherit
 
   docker_examples:
@@ -237,7 +237,7 @@ jobs:
     with:
       ANSYS_VERSION: ${{ github.event.inputs.ansys_version || '251' }}
       python_versions: '["3.9", "3.10", "3.11"]'
-      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '.pre0' }}
+      standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
     secrets: inherit
 
   draft_release:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -316,7 +316,7 @@ jobs:
       - name: "Test API test_service"
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 2
+          timeout_minutes: 3
           max_attempts: 2
           shell: bash
           command: |


### PR DESCRIPTION
DPF `2025.1.0` has been officially released with `ANSYS 2025 R1` and is the latest publicly available version to test against when releasing `ansys-dpf-core`.