### PR TITLE
Accept rank-1 NumPy arrays for workflow and operator inputs which accept lists 

### DIFF
--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -39,7 +39,6 @@ from ansys.dpf.core.errors import DpfVersionNotSupported
 from ansys.dpf.core.inputs import Inputs
 from ansys.dpf.core.mapping_types import types
 from ansys.dpf.core.common import types_enum_to_types
-from ansys.dpf.core.misc import get_array_length
 from ansys.dpf.core.outputs import Output, Outputs, _Outputs
 from ansys.dpf.core import server as server_module
 from ansys.dpf.core.operator_specification import Specification

--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -288,7 +288,9 @@ class Operator:
                 if all(isinstance(x, int) for x in inpt):
                     self._api.operator_connect_vector_int(self, pin, inpt, get_array_length(inpt))
                 else:
-                    self._api.operator_connect_vector_double(self, pin, inpt, get_array_length(inpt))
+                    self._api.operator_connect_vector_double(
+                        self, pin, inpt, get_array_length(inpt)
+                    )
         elif isinstance(inpt, dict):
             from ansys.dpf.core import label_space
 

--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -281,17 +281,8 @@ class Operator:
         elif isinstance(inpt, (list, numpy.ndarray)):
             from ansys.dpf.core import collection
 
-            if server_meet_version("3.0", self._server):
-                inpt = collection.CollectionBase.integral_collection(inpt, self._server)
-                self._api.operator_connect_collection_as_vector(self, pin, inpt)
-            else:  # pragma: nocover
-                # Exclude DPF below 2022R1 from coverage
-                if all(isinstance(x, int) for x in inpt):
-                    self._api.operator_connect_vector_int(self, pin, inpt, get_array_length(inpt))
-                else:
-                    self._api.operator_connect_vector_double(
-                        self, pin, inpt, get_array_length(inpt)
-                    )
+            inpt = collection.CollectionBase.integral_collection(inpt, self._server)
+            self._api.operator_connect_collection_as_vector(self, pin, inpt)
         elif isinstance(inpt, dict):
             from ansys.dpf.core import label_space
 

--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -284,7 +284,8 @@ class Operator:
             if server_meet_version("3.0", self._server):
                 inpt = collection.CollectionBase.integral_collection(inpt, self._server)
                 self._api.operator_connect_collection_as_vector(self, pin, inpt)
-            else:
+            else:  # pragma: nocover
+                # Exclude DPF below 2022R1 from coverage
                 if all(isinstance(x, int) for x in inpt):
                     self._api.operator_connect_vector_int(self, pin, inpt, get_array_length(inpt))
                 else:

--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -26,6 +26,7 @@ import logging
 import os
 import traceback
 import warnings
+import numpy
 
 from enum import Enum
 from ansys.dpf.core.check_version import (
@@ -38,6 +39,7 @@ from ansys.dpf.core.errors import DpfVersionNotSupported
 from ansys.dpf.core.inputs import Inputs
 from ansys.dpf.core.mapping_types import types
 from ansys.dpf.core.common import types_enum_to_types
+from ansys.dpf.core.misc import get_array_length
 from ansys.dpf.core.outputs import Output, Outputs, _Outputs
 from ansys.dpf.core import server as server_module
 from ansys.dpf.core.operator_specification import Specification
@@ -276,7 +278,7 @@ class Operator:
             self._api.operator_connect_operator_output(self, pin, inpt, pin_out)
         elif isinstance(inpt, Output):
             self._api.operator_connect_operator_output(self, pin, inpt._operator, inpt._pin)
-        elif isinstance(inpt, list):
+        elif isinstance(inpt, (list, numpy.ndarray)):
             from ansys.dpf.core import collection
 
             if server_meet_version("3.0", self._server):
@@ -284,9 +286,9 @@ class Operator:
                 self._api.operator_connect_collection_as_vector(self, pin, inpt)
             else:
                 if all(isinstance(x, int) for x in inpt):
-                    self._api.operator_connect_vector_int(self, pin, inpt, len(inpt))
+                    self._api.operator_connect_vector_int(self, pin, inpt, get_array_length(inpt))
                 else:
-                    self._api.operator_connect_vector_double(self, pin, inpt, len(inpt))
+                    self._api.operator_connect_vector_double(self, pin, inpt, get_array_length(inpt))
         elif isinstance(inpt, dict):
             from ansys.dpf.core import label_space
 

--- a/src/ansys/dpf/core/misc.py
+++ b/src/ansys/dpf/core/misc.py
@@ -29,6 +29,10 @@ import re
 from pathlib import Path
 
 from pkgutil import iter_modules
+from typing import Union
+
+import numpy
+
 from ansys.dpf.core import errors
 from ansys.dpf.gate._version import __ansys_version__
 from ansys.dpf.gate import load_api
@@ -213,3 +217,9 @@ def is_pypim_configured():
         ``True`` if the environment is setup to use the PIM API, ``False`` otherwise.
     """
     return "ANSYS_PLATFORM_INSTANCEMANAGEMENT_CONFIG" in os.environ
+
+
+def get_array_length(array:Union[list, numpy.ndarray]):
+    if isinstance(array, numpy.ndarray):
+        return array.size
+    return len(array)

--- a/src/ansys/dpf/core/misc.py
+++ b/src/ansys/dpf/core/misc.py
@@ -219,7 +219,8 @@ def is_pypim_configured():
     return "ANSYS_PLATFORM_INSTANCEMANAGEMENT_CONFIG" in os.environ
 
 
-def get_array_length(array:Union[list, numpy.ndarray]):
+def get_array_length(array: Union[list, numpy.ndarray]):
+    """Return the length of a flat array (size of numpy array or length of a list."""
     if isinstance(array, numpy.ndarray):
         return array.size
     return len(array)

--- a/src/ansys/dpf/core/misc.py
+++ b/src/ansys/dpf/core/misc.py
@@ -29,10 +29,6 @@ import re
 from pathlib import Path
 
 from pkgutil import iter_modules
-from typing import Union
-
-import numpy
-
 from ansys.dpf.core import errors
 from ansys.dpf.gate._version import __ansys_version__
 from ansys.dpf.gate import load_api
@@ -217,10 +213,3 @@ def is_pypim_configured():
         ``True`` if the environment is setup to use the PIM API, ``False`` otherwise.
     """
     return "ANSYS_PLATFORM_INSTANCEMANAGEMENT_CONFIG" in os.environ
-
-
-def get_array_length(array: Union[list, numpy.ndarray]):
-    """Return the length of a flat array (size of numpy array or length of a list."""
-    if isinstance(array, numpy.ndarray):
-        return array.size
-    return len(array)

--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -41,7 +41,6 @@ from ansys.dpf.core.check_version import (
     server_meet_version_and_raise,
 )
 from ansys.dpf.core import server as server_module
-from ansys.dpf.core.misc import get_array_length
 from ansys.dpf.gate import (
     workflow_abstract_api,
     workflow_grpcapi,

--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -220,18 +220,8 @@ class Workflow:
         elif isinstance(inpt, (list, numpy.ndarray)):
             from ansys.dpf.core import collection
 
-            if server_meet_version("3.0", self._server):
-                inpt = collection.CollectionBase.integral_collection(inpt, self._server)
-                self._api.work_flow_connect_collection_as_vector(self, pin_name, inpt)
-            else:
-                if all(isinstance(x, int) for x in inpt):
-                    self._api.work_flow_connect_vector_int(
-                        self, pin_name, inpt, get_array_length(inpt)
-                    )
-                else:
-                    self._api.work_flow_connect_vector_double(
-                        self, pin_name, inpt, get_array_length(inpt)
-                    )
+            inpt = collection.CollectionBase.integral_collection(inpt, self._server)
+            self._api.work_flow_connect_collection_as_vector(self, pin_name, inpt)
         elif isinstance(inpt, dict):
             from ansys.dpf.core import label_space
 

--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -31,6 +31,8 @@ from pathlib import Path
 from enum import Enum
 from typing import Union
 
+import numpy
+
 from ansys import dpf
 from ansys.dpf.core import dpf_operator, inputs, outputs
 from ansys.dpf.core.check_version import (
@@ -39,6 +41,7 @@ from ansys.dpf.core.check_version import (
     server_meet_version_and_raise,
 )
 from ansys.dpf.core import server as server_module
+from ansys.dpf.core.misc import get_array_length
 from ansys.dpf.gate import (
     workflow_abstract_api,
     workflow_grpcapi,
@@ -214,7 +217,7 @@ class Workflow:
             self._api.work_flow_connect_operator_output(self, pin_name, inpt, pin_out)
         elif isinstance(inpt, dpf_operator.Output):
             self._api.work_flow_connect_operator_output(self, pin_name, inpt._operator, inpt._pin)
-        elif isinstance(inpt, list):
+        elif isinstance(inpt, (list, numpy.ndarray)):
             from ansys.dpf.core import collection
 
             if server_meet_version("3.0", self._server):
@@ -222,9 +225,9 @@ class Workflow:
                 self._api.work_flow_connect_collection_as_vector(self, pin_name, inpt)
             else:
                 if all(isinstance(x, int) for x in inpt):
-                    self._api.work_flow_connect_vector_int(self, pin_name, inpt, len(inpt))
+                    self._api.work_flow_connect_vector_int(self, pin_name, inpt, get_array_length(inpt))
                 else:
-                    self._api.work_flow_connect_vector_double(self, pin_name, inpt, len(inpt))
+                    self._api.work_flow_connect_vector_double(self, pin_name, inpt, get_array_length(inpt))
         elif isinstance(inpt, dict):
             from ansys.dpf.core import label_space
 

--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -225,9 +225,13 @@ class Workflow:
                 self._api.work_flow_connect_collection_as_vector(self, pin_name, inpt)
             else:
                 if all(isinstance(x, int) for x in inpt):
-                    self._api.work_flow_connect_vector_int(self, pin_name, inpt, get_array_length(inpt))
+                    self._api.work_flow_connect_vector_int(
+                        self, pin_name, inpt, get_array_length(inpt)
+                    )
                 else:
-                    self._api.work_flow_connect_vector_double(self, pin_name, inpt, get_array_length(inpt))
+                    self._api.work_flow_connect_vector_double(
+                        self, pin_name, inpt, get_array_length(inpt)
+                    )
         elif isinstance(inpt, dict):
             from ansys.dpf.core import label_space
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -27,6 +27,7 @@ import types
 import weakref
 from pathlib import Path
 
+import numpy
 import numpy as np
 import pytest
 import copy
@@ -89,6 +90,13 @@ def test_connect_list_operator(velocity_acceleration):
     model = dpf.core.Model(velocity_acceleration)
     op = model.operator("U")
     op.connect(0, [1, 2])
+    fcOut = op.get_output(0, dpf.core.types.fields_container)
+    assert fcOut.get_available_ids_for_label() == [1, 2]
+
+def test_connect_array_operator(velocity_acceleration):
+    model = dpf.core.Model(velocity_acceleration)
+    op = model.operator("U")
+    op.connect(0, numpy.array([1, 2], numpy.int32))
     fcOut = op.get_output(0, dpf.core.types.fields_container)
     assert fcOut.get_available_ids_for_label() == [1, 2]
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -93,6 +93,7 @@ def test_connect_list_operator(velocity_acceleration):
     fcOut = op.get_output(0, dpf.core.types.fields_container)
     assert fcOut.get_available_ids_for_label() == [1, 2]
 
+
 def test_connect_array_operator(velocity_acceleration):
     model = dpf.core.Model(velocity_acceleration)
     op = model.operator("U")

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -22,6 +22,7 @@
 
 from pathlib import Path
 
+import numpy
 import numpy as np
 import pytest
 import platform
@@ -133,6 +134,19 @@ def test_connect_list_workflow(velocity_acceleration, server_type):
     wf.set_input_name("time_scoping", op.inputs.time_scoping)
     wf.set_output_name("field", op.outputs.fields_container)
     wf.connect("time_scoping", [1, 2])
+    f_out = wf.get_output("field", dpf.core.types.fields_container)
+    assert f_out.get_available_ids_for_label() == [1, 2]
+
+
+def test_connect_array_workflow(velocity_acceleration, server_type):
+    wf = dpf.core.Workflow(server=server_type)
+    wf.progress_bar = False
+    model = dpf.core.Model(velocity_acceleration, server=server_type)
+    op = model.operator("U")
+    wf.add_operator(op)
+    wf.set_input_name("time_scoping", op, 0)
+    wf.set_output_name("field", op, 0)
+    wf.connect("time_scoping", numpy.array([1, 2], numpy.int32))
     f_out = wf.get_output("field", dpf.core.types.fields_container)
     assert f_out.get_available_ids_for_label() == [1, 2]
 


### PR DESCRIPTION
This adds support for giving lists to operator or workflow inputs in the format of a rank 1 NumPy array.