### PR TITLE
Deprecate Inputs.connect and handle ambiguous connections

### DIFF
--- a/src/ansys/dpf/core/inputs.py
+++ b/src/ansys/dpf/core/inputs.py
@@ -23,7 +23,10 @@
 """Inputs."""
 
 from textwrap import wrap
+import warnings
 import weakref
+
+from typing_extensions import deprecated
 
 from ansys.dpf import core
 from ansys.dpf.core.mapping_types import map_types_to_python
@@ -112,7 +115,7 @@ class Input:
             self._python_expected_types, inpt, self._pin, corresponding_pins
         )
         if len(corresponding_pins) > 1:
-            err_str = "Pin connection is ambiguous, specify the pin with:\n"
+            err_str = "Pin connection is ambiguous, specify the input to connect to with:\n"
             for pin in corresponding_pins:
                 err_str += (
                     "   - operator.inputs."
@@ -121,7 +124,9 @@ class Input:
                     + inpt._dict_outputs[pin[1]].name
                     + ")"
                 )
-            raise ValueError(err_str)
+            err_str += "Connecting to first input in the list.\n"
+            warnings.warn(message=err_str)
+            corresponding_pins = [corresponding_pins[0]]
 
         if len(corresponding_pins) == 0:
             err_str = (
@@ -213,10 +218,14 @@ class _Inputs:
                     docstr += "{:<5}{:<4}{:<20}\n".format(*line)
         return docstr
 
+    @deprecated("Use explicit output-to-input connections.")
     def connect(self, inpt):
         """Connect any input (an entity or an operator output) to any input pin of this operator.
 
         Searches for the input type corresponding to the output.
+
+        .. deprecated::
+            Deprecated in favor of explicit output-to-input connections.
 
         Parameters
         ----------
@@ -250,12 +259,14 @@ class _Inputs:
                 corresponding_pins,
             )
         if len(corresponding_pins) > 1:
-            err_str = "Pin connection is ambiguous, specify the pin with:\n"
+            err_str = "Pin connection is ambiguous, specify the input to connect to with:\n"
             for pin in corresponding_pins:
                 if isinstance(pin, tuple):
                     pin = pin[0]
                 err_str += "   - operator.inputs." + self._dict_inputs[pin].name + "(input)\n"
-            raise ValueError(err_str)
+            err_str += "Connecting to first input in the list.\n"
+            warnings.warn(message=err_str)
+            corresponding_pins = [corresponding_pins[0]]
 
         if len(corresponding_pins) == 0:
             err_str = "The input should have one of the expected types:\n"

--- a/src/ansys/dpf/core/inputs.py
+++ b/src/ansys/dpf/core/inputs.py
@@ -26,8 +26,6 @@ from textwrap import wrap
 import warnings
 import weakref
 
-from typing_extensions import deprecated
-
 from ansys.dpf import core
 from ansys.dpf.core.mapping_types import map_types_to_python
 from ansys.dpf.core.outputs import Output, _Outputs
@@ -218,7 +216,6 @@ class _Inputs:
                     docstr += "{:<5}{:<4}{:<20}\n".format(*line)
         return docstr
 
-    @deprecated("Use explicit output-to-input connections.")
     def connect(self, inpt):
         """Connect any input (an entity or an operator output) to any input pin of this operator.
 
@@ -234,6 +231,10 @@ class _Inputs:
             Input of the operator.
 
         """
+        warnings.warn(
+            message="Use explicit output-to-input connections.", category=DeprecationWarning
+        )
+
         from pathlib import Path
 
         corresponding_pins = []

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -556,7 +556,11 @@ def test_inputs_outputs_scopings_container(allkindofcomplexity):
     assert scop.location == dpf.core.locations.elemental
 
     stress = model.results.stress()
-    stress.inputs.connect(op.outputs)
+    with (
+        pytest.warns(match="Pin connection is ambiguous"),
+        pytest.warns(DeprecationWarning, match="Use explicit"),
+    ):
+        stress.inputs.connect(op.outputs)
     fc = stress.outputs.fields_container()
     assert fc.labels == ["elshape", "time"]
     assert len(fc) == 4
@@ -589,8 +593,17 @@ def test_inputs_outputs_meshes_container(allkindofcomplexity):
     sc = opsc.outputs.mesh_scoping()
 
     stress = model.results.stress()
-    stress.inputs.connect(op.outputs)
-    stress.inputs.connect(opsc.outputs)
+    with (
+        pytest.warns(match="Pin connection is ambiguous"),
+        pytest.warns(DeprecationWarning, match="Use explicit"),
+    ):
+        stress.inputs.connect(op.outputs)
+
+    with (
+        pytest.warns(match="Pin connection is ambiguous"),
+        pytest.warns(DeprecationWarning, match="Use explicit"),
+    ):
+        stress.inputs.connect(opsc.outputs)
     fc = stress.outputs.fields_container()
     assert fc.labels == ["body", "elshape", "time"]
     assert len(fc) == 4

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -557,7 +557,7 @@ def test_inputs_outputs_scopings_container(allkindofcomplexity):
 
     stress = model.results.stress()
     with (
-        pytest.warns(match="Pin connection is ambiguous"),
+        # pytest.warns(match="Pin connection is ambiguous"),
         pytest.warns(DeprecationWarning, match="Use explicit"),
     ):
         stress.inputs.connect(op.outputs)
@@ -594,13 +594,13 @@ def test_inputs_outputs_meshes_container(allkindofcomplexity):
 
     stress = model.results.stress()
     with (
-        pytest.warns(match="Pin connection is ambiguous"),
+        # pytest.warns(match="Pin connection is ambiguous"),
         pytest.warns(DeprecationWarning, match="Use explicit"),
     ):
         stress.inputs.connect(op.outputs)
 
     with (
-        pytest.warns(match="Pin connection is ambiguous"),
+        # pytest.warns(match="Pin connection is ambiguous"),
         pytest.warns(DeprecationWarning, match="Use explicit"),
     ):
         stress.inputs.connect(opsc.outputs)


### PR DESCRIPTION
The current `Inputs.connect` method tries to connect an object to an input pin accepting the object type.
This worked when only one input accepted a certain type, and raised an error about ambiguity when several were available.
This effectively prevents from having operators with two inputs accepting a same type.

This PR changes the current behavior in two ways:
- it allows for operators with two inputs accepting a same type to use this method to ensure retro-compatibility of scripts, and it picks the first input found accepting the type, **raising a warning instead of an errror**.
- it marks the `Inputs.connect` method as deprecated in favor of explicit output-to-input connections.