### PR TITLE
Revert "fix: remove black as a dependency"

### DIFF
--- a/requirements/requirements_build.txt
+++ b/requirements/requirements_build.txt
@@ -1,3 +1,4 @@
+black==24.10.0
 build==1.2.2.post1
 chevron==0.14.0
 wheel==0.45.1


### PR DESCRIPTION
Reverts ansys/pydpf-core#2052

`black` is currently used when generating the python code for operators [here](https://github.com/ansys/pydpf-core/blob/f3d5f989e8763f70c389457ed304d623eec9ac1a/src/ansys/dpf/core/operators/build.py#L168).