### PR TITLE
Only ask integration_proxies for review for operator updates on main branch

### DIFF
--- a/.github/workflows/update_operators.yml
+++ b/.github/workflows/update_operators.yml
@@ -138,8 +138,7 @@ jobs:
           branch: maint/update_code_for_${{ github.event.inputs.ANSYS_VERSION || '251' }}${{ github.event.inputs.standalone_branch_suffix || '' }}_on_${{ github.ref_name }}
           labels: server-sync
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
-          reviewers: ansys/dpf_integration_proxies
-          assignees: ansys/dpf_integration_proxies
+          reviewers: ${{ github.ref_name == 'master' && 'ansys/dpf_integration_proxies' || '' }}
 
       - name: "Kill all servers"
         uses: ansys/pydpf-actions/kill-dpf-servers@v2.3


### PR DESCRIPTION
While running test operator update actions, the `integration_proxies` keep being added as reviewer despite the generated PR being on a feature branch.
This limits it to operator update PRs on the default branch.

See [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example) for example of `if/else` in GitHub actions expressions.