### PR TITLE
Maint: Remove google-api-python-client from dependencies 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "google-api-python-client",
     "grpcio >=1.63.0",
     "importlib-metadata >=4.0",
     "numpy",


### PR DESCRIPTION
Removing unused dependency brought during merge of `ansys-dpf-core` with `ansys-grpc-dpf` and `ansys-dpf-gate`.

Thanks @koubaa for the catch