### PR TITLE
fix: requirements

### DIFF
--- a/requirements/requirements_build.txt
+++ b/requirements/requirements_build.txt
@@ -1,4 +1,3 @@
-black==25.1.0
 build==1.2.2.post1
 chevron==0.14.0
 wheel==0.45.1


### PR DESCRIPTION
Removes empty file and `black` as a dependency in favor of Ruff.