### PR TITLE
Handle connection of Enum to operators

### DIFF
--- a/src/ansys/dpf/core/inputs.py
+++ b/src/ansys/dpf/core/inputs.py
@@ -22,6 +22,7 @@
 
 """Inputs."""
 
+from enum import Enum
 from textwrap import wrap
 import warnings
 import weakref
@@ -73,7 +74,7 @@ class Input:
 
         Parameters
         ----------
-        inpt : str, int, double, Field, FieldsContainer, Scoping, DataSources, MeshedRegion,
+        inpt : str, int, double, Field, FieldsContainer, Scoping, DataSources, MeshedRegion, Enum,
         Output, Outputs, Operator, os.PathLike
             Input of the operator.
 
@@ -100,6 +101,8 @@ class Input:
                 inpt = inpt.ID
             else:  # Custom UnitSystem
                 inpt = inpt.unit_names
+        elif isinstance(inpt, Enum):
+            inpt = inpt.value
 
         input_type_name = type(inpt).__name__
         if not (input_type_name in self._python_expected_types or ["Outputs", "Output", "Any"]):
@@ -226,7 +229,7 @@ class _Inputs:
 
         Parameters
         ----------
-        inpt : str, int, double, bool, list[int], list[float], Field, FieldsContainer, Scoping,
+        inpt : str, int, double, bool, list[int], list[float], Field, FieldsContainer, Scoping, Enum,
         ScopingsContainer, MeshedRegion, MeshesContainer, DataSources, CyclicSupport, Outputs, os.PathLike  # noqa: E501
             Input of the operator.
 
@@ -250,6 +253,8 @@ class _Inputs:
             inpt = inpt.metadata.data_sources
         elif isinstance(inpt, Path):
             inpt = str(inpt)
+        elif isinstance(inpt, Enum):
+            inpt = inpt.value
 
         input_type_name = type(inpt).__name__
         for input_pin in self._inputs:

--- a/tests/operators/test_change_shell_layers.py
+++ b/tests/operators/test_change_shell_layers.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2020 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Tests the utility.change_shell_layers operator
+
+import ansys.dpf.core as dpf
+from ansys.dpf.core import examples
+
+
+def test_operator_change_shell_layers_connect_enum(server_type):
+    model = dpf.Model(
+        examples.download_all_kinds_of_complexity_modal(server=server_type), server=server_type
+    )
+
+    stress = model.results.stress()
+    stress.inputs.requested_location.connect("Nodal")
+
+    # Test connection through signature
+    change_shell_layers = dpf.operators.utility.change_shell_layers(
+        fields_container=stress, e_shell_layer=dpf.common.shell_layers.bottom, server=server_type
+    )
+    _ = change_shell_layers.eval()
+
+    # Test connection through Input.connect
+    change_shell_layers = dpf.operators.utility.change_shell_layers(server=server_type)
+    change_shell_layers.inputs.fields_container.connect(stress)
+    change_shell_layers.inputs.e_shell_layer.connect(dpf.common.shell_layers.bottom)
+    _ = change_shell_layers.eval()
+
+    # Test connection through Inputs.connect
+    change_shell_layers = dpf.operators.utility.change_shell_layers(server=server_type)
+    change_shell_layers.inputs.connect(stress)
+    change_shell_layers.inputs.connect(dpf.common.shell_layers.bottom)
+    _ = change_shell_layers.eval()


### PR DESCRIPTION
Solves #210 

Operators do not take `Enum` as input, so `Enum` types must be translated to their `int` value.
This issue was found for the `shell_layers` Enum when trying to connect it to the `change_shell_layers` operator.