### PR TITLE
Fix specification.config_specification on empty spec

### DIFF
--- a/src/ansys/dpf/core/operator_specification.py
+++ b/src/ansys/dpf/core/operator_specification.py
@@ -460,6 +460,7 @@ class Specification(SpecificationBase):
         """
         if self._config_specification is None:
             self._config_specification = ConfigSpecification()
+        if self._internal_obj is not None:
             num_options = self._api.operator_specification_get_num_config_options(self)
             for i in range(num_options):
                 option_name = self._api.operator_specification_get_config_name(self, i)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1328,6 +1328,16 @@ def test_generated_operator_config_specification_simple(server_type):
     assert "id" in conf_spec["work_by_index"].document
 
 
+def test_empty_specification(server_type):
+    op = dpf.core.dpf_operator.Operator("chunk_fc", server=server_type)
+    spec = op.specification
+    _ = spec.config_specification
+    _ = spec.properties
+    _ = spec.description
+    _ = spec.inputs
+    _ = spec.outputs
+
+
 def test_operator_exception():
     ds = dpf.core.DataSources(r"dummy/file.rst")
     op = ops.result.displacement(data_sources=ds)


### PR DESCRIPTION
This used to throw an "invalid type" CLayer error for an empty `Specification` when `InProcess`. Now it returns an empty `ConfigSpecification`.