### PR TITLE
Raise useful error on workflow.connect_with for wrong labels

### DIFF
--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -22,6 +22,8 @@
 
 """Workflow."""
 
+from __future__ import annotations
+
 from enum import Enum
 import logging
 import os
@@ -714,7 +716,11 @@ class Workflow:
         return out
 
     @version_requires("3.0")
-    def connect_with(self, left_workflow, output_input_names=None):
+    def connect_with(
+        self,
+        left_workflow: Workflow,
+        output_input_names: Union[tuple[str, str], dict[str, str]] = None,
+    ):
         """Prepend a given workflow to the current workflow.
 
         Updates the current workflow to include all the operators of the workflow given as argument.
@@ -724,9 +730,9 @@ class Workflow:
 
         Parameters
         ----------
-        left_workflow : core.Workflow
+        left_workflow:
             The given workflow's outputs are chained with the current workflow's inputs.
-        output_input_names : str tuple, str dict optional
+        output_input_names:
             Map used to connect the outputs of the given workflow to the inputs of the current
             workflow.
             Check the names of available inputs and outputs for each workflow using

--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -715,6 +715,35 @@ class Workflow:
             out.append(self._api.work_flow_output_by_index(self, i))
         return out
 
+    def safe_connect_with(
+        self,
+        left_workflow: Workflow,
+        output_input_names: Union[tuple[str, str], dict[str, str]],
+    ):
+        """Prepend a given workflow to the current workflow for valid connections only.
+
+        See Workflow.connect_with for more information on the connection logic.
+
+        Parameters
+        ----------
+        left_workflow:
+            The given workflow's outputs are chained with the current workflow's inputs.
+        output_input_names:
+            Map used to connect the outputs of the given workflow to the inputs of the current
+            workflow.
+            Check the names of available inputs and outputs for each workflow using
+            `Workflow.input_names` and `Workflow.output_names`.
+        """
+        if isinstance(output_input_names, tuple):
+            output_input_names = {output_input_names[0]: output_input_names[1]}
+        valid_connections = dict(
+            filter(
+                lambda item: item[0] in left_workflow.output_names and item[1] in self.input_names,
+                output_input_names.items(),
+            )
+        )
+        self.connect_with(left_workflow, valid_connections)
+
     @version_requires("3.0")
     def connect_with(
         self,

--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -814,7 +814,7 @@ class Workflow:
                     self._api.workflow_add_entry_connection_map(map, key, output_input_names[key])
             else:
                 raise TypeError(
-                    "output_input_names argument is expect" "to be either a str tuple or a str dict"
+                    "output_input_names argument is expected to be either a str tuple or a str dict"
                 )
             self._api.work_flow_connect_with_specified_names(self, left_workflow, map)
         else:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -715,6 +715,22 @@ def test_workflow_connect_raise_wrong_label(server_type):
     workflow2.connect_with(workflow1, output_input_names={"output": "input"})
 
 
+def test_workflow_safe_connect_with(server_type):
+    workflow1 = dpf.core.Workflow()
+    forward_1 = dpf.core.operators.utility.forward()
+    workflow1.set_output_name("output", forward_1.outputs.any)
+
+    workflow2 = dpf.core.Workflow()
+    forward_2 = dpf.core.operators.utility.forward()
+    workflow2.set_input_name("input", forward_2.inputs.any)
+
+    workflow2.safe_connect_with(workflow1, output_input_names={"out": "input"})
+
+    workflow2.safe_connect_with(workflow1, output_input_names={"output": "in"})
+
+    workflow2.safe_connect_with(workflow1, output_input_names=("output", "input"))
+
+
 @pytest.mark.xfail(raises=dpf.core.errors.ServerTypeError)
 def test_info_workflow(allkindofcomplexity, server_type):
     model = dpf.core.Model(allkindofcomplexity, server=server_type)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -707,15 +707,15 @@ def test_workflow_connect_raise_wrong_label(server_type):
     with pytest.raises(
         ValueError, match="Cannot connect workflow output 'out'. Exposed outputs are:\n"
     ):
-        workflow2.connect_with(workflow1, output_input_names={"out": "input"})
+        workflow2.connect_with(workflow1, output_input_names={"out": "input"}, permissive=False)
     with pytest.raises(
         ValueError, match="Cannot connect workflow input 'in'. Exposed inputs are:\n"
     ):
-        workflow2.connect_with(workflow1, output_input_names={"output": "in"})
-    workflow2.connect_with(workflow1, output_input_names={"output": "input"})
+        workflow2.connect_with(workflow1, output_input_names={"output": "in"}, permissive=False)
+    workflow2.connect_with(workflow1, output_input_names={"output": "input"}, permissive=False)
 
 
-def test_workflow_safe_connect_with(server_type):
+def test_workflow_connect_with_permissive(server_type):
     workflow1 = dpf.core.Workflow()
     forward_1 = dpf.core.operators.utility.forward()
     workflow1.set_output_name("output", forward_1.outputs.any)
@@ -724,11 +724,11 @@ def test_workflow_safe_connect_with(server_type):
     forward_2 = dpf.core.operators.utility.forward()
     workflow2.set_input_name("input", forward_2.inputs.any)
 
-    workflow2.safe_connect_with(workflow1, output_input_names={"out": "input"})
+    workflow2.connect_with(workflow1, output_input_names={"out": "input"})
 
-    workflow2.safe_connect_with(workflow1, output_input_names={"output": "in"})
+    workflow2.connect_with(workflow1, output_input_names={"output": "in"})
 
-    workflow2.safe_connect_with(workflow1, output_input_names=("output", "input"))
+    workflow2.connect_with(workflow1, output_input_names=("output", "input"))
 
 
 @pytest.mark.xfail(raises=dpf.core.errors.ServerTypeError)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -695,6 +695,26 @@ def test_connect_with_dict_workflow(cyclic_lin_rst, cyclic_ds, server_type):
     fc = wf2.get_output("u", dpf.core.types.fields_container)
 
 
+def test_workflow_connect_raise_wrong_label(server_type):
+    workflow1 = dpf.core.Workflow()
+    forward_1 = dpf.core.operators.utility.forward()
+    workflow1.set_output_name("output", forward_1.outputs.any)
+
+    workflow2 = dpf.core.Workflow()
+    forward_2 = dpf.core.operators.utility.forward()
+    workflow2.set_input_name("input", forward_2.inputs.any)
+
+    with pytest.raises(
+        ValueError, match="Cannot connect workflow output 'out'. Exposed outputs are:\n"
+    ):
+        workflow2.connect_with(workflow1, output_input_names={"out": "input"})
+    with pytest.raises(
+        ValueError, match="Cannot connect workflow input 'in'. Exposed inputs are:\n"
+    ):
+        workflow2.connect_with(workflow1, output_input_names={"output": "in"})
+    workflow2.connect_with(workflow1, output_input_names={"output": "input"})
+
+
 @pytest.mark.xfail(raises=dpf.core.errors.ServerTypeError)
 def test_info_workflow(allkindofcomplexity, server_type):
     model = dpf.core.Model(allkindofcomplexity, server=server_type)


### PR DESCRIPTION
Solves #928 

PR on PyDPF-Post will make use of new `Workflow.safe_connect_with()`.

Edit: not sure about the naming. Should it rather be `Workflow.connect_with_available`, or something else? @BClappe 

Also I realize that changing the behavior of `Workflow.connect_with` to now raise if an input or output is unavailable, is a breaking change of a sort. Maybe we should actually keep `connect_with` as-is or even put the filtering logic there, and create a new method `Workflow.connect_with_error` which raises in the case of an unavailable input or output. What do you think? 