### PR TITLE
DpfVector BUG: DpfVector were created on one clayer and deleted in another 

### DIFF
--- a/src/ansys/dpf/core/collection_base.py
+++ b/src/ansys/dpf/core/collection_base.py
@@ -655,7 +655,7 @@ class IntCollection(CollectionBase[int]):
     def get_integral_entries(self):
         """Get integral entries."""
         try:
-            vec = dpf_vector.DPFVectorInt(client=self._server.client)
+            vec = dpf_vector.DPFVectorInt(owner=self)
             self._api.collection_get_data_as_int_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size
             )
@@ -715,7 +715,7 @@ class FloatCollection(CollectionBase[float]):
     def get_integral_entries(self):
         """Get integral entries."""
         try:
-            vec = dpf_vector.DPFVectorDouble(client=self._server.client)
+            vec = dpf_vector.DPFVectorDouble(owner=self)
             self._api.collection_get_data_as_double_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size
             )

--- a/src/ansys/dpf/core/custom_type_field.py
+++ b/src/ansys/dpf/core/custom_type_field.py
@@ -326,7 +326,7 @@ class CustomTypeField(_FieldBase):
 
         """
         try:
-            vec = dpf_vector.DPFVectorCustomType(self._type, client=self._server.client)
+            vec = dpf_vector.DPFVectorCustomType(self._type, owner=self)
             self._api.cscustom_type_field_get_entity_data_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size, index
             )
@@ -366,7 +366,7 @@ class CustomTypeField(_FieldBase):
 
         """
         try:
-            vec = dpf_vector.DPFVectorCustomType(self._type, client=self._server.client)
+            vec = dpf_vector.DPFVectorCustomType(self._type, owner=self)
             self._api.cscustom_type_field_get_entity_data_by_id_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size, id
             )
@@ -390,7 +390,7 @@ class CustomTypeField(_FieldBase):
 
     def _get_data_pointer(self):
         try:
-            vec = dpf_vector.DPFVectorInt(client=self._server.client)
+            vec = dpf_vector.DPFVectorInt(owner=self)
             self._api.cscustom_type_field_get_data_pointer_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size
             )
@@ -404,7 +404,7 @@ class CustomTypeField(_FieldBase):
 
     def _get_data(self, np_array=True):
         try:
-            vec = dpf_vector.DPFVectorCustomType(self._type, client=self._server.client)
+            vec = dpf_vector.DPFVectorCustomType(self._type, owner=self)
             self._api.cscustom_type_field_get_data_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size
             )

--- a/src/ansys/dpf/core/field.py
+++ b/src/ansys/dpf/core/field.py
@@ -409,7 +409,7 @@ class Field(_FieldBase):
     def get_entity_data(self, index: int) -> dpf_array.DPFArray:
         """Retrieve entity data by index."""
         try:
-            vec = dpf_vector.DPFVectorDouble(client=self._server.client)
+            vec = dpf_vector.DPFVectorDouble(owner=self)
             self._api.csfield_get_entity_data_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size, index
             )
@@ -425,7 +425,7 @@ class Field(_FieldBase):
     def get_entity_data_by_id(self, id: int) -> dpf_array.DPFArray:
         """Retrieve entity data by id."""
         try:
-            vec = dpf_vector.DPFVectorDouble(client=self._server.client)
+            vec = dpf_vector.DPFVectorDouble(owner=self)
             self._api.csfield_get_entity_data_by_id_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size, id
             )
@@ -450,7 +450,7 @@ class Field(_FieldBase):
 
     def _get_data_pointer(self):
         try:
-            vec = dpf_vector.DPFVectorInt(client=self._server.client)
+            vec = dpf_vector.DPFVectorInt(owner=self)
             self._api.csfield_get_data_pointer_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size
             )
@@ -464,7 +464,7 @@ class Field(_FieldBase):
 
     def _get_data(self, np_array=True):
         try:
-            vec = dpf_vector.DPFVectorDouble(client=self._server.client)
+            vec = dpf_vector.DPFVectorDouble(owner=self)
             self._api.csfield_get_data_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size
             )

--- a/src/ansys/dpf/core/property_field.py
+++ b/src/ansys/dpf/core/property_field.py
@@ -223,7 +223,7 @@ class PropertyField(_FieldBase):
     def get_entity_data(self, index):
         """Return the data associated with the entity by index."""
         try:
-            vec = dpf_vector.DPFVectorInt(client=self._server.client)
+            vec = dpf_vector.DPFVectorInt(owner=self)
             self._api.csproperty_field_get_entity_data_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size, index
             )
@@ -239,7 +239,7 @@ class PropertyField(_FieldBase):
     def get_entity_data_by_id(self, id):
         """Return the data associated with entity by id."""
         try:
-            vec = dpf_vector.DPFVectorInt(client=self._server.client)
+            vec = dpf_vector.DPFVectorInt(owner=self)
             self._api.csproperty_field_get_entity_data_by_id_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size, id
             )
@@ -264,7 +264,7 @@ class PropertyField(_FieldBase):
 
     def _get_data_pointer(self):
         try:
-            vec = dpf_vector.DPFVectorInt(client=self._server.client)
+            vec = dpf_vector.DPFVectorInt(owner=self)
             self._api.csproperty_field_get_data_pointer_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size
             )
@@ -278,7 +278,7 @@ class PropertyField(_FieldBase):
 
     def _get_data(self, np_array=True):
         try:
-            vec = dpf_vector.DPFVectorInt(client=self._server.client)
+            vec = dpf_vector.DPFVectorInt(owner=self)
             self._api.csproperty_field_get_data_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size
             )

--- a/src/ansys/dpf/core/scoping.py
+++ b/src/ansys/dpf/core/scoping.py
@@ -235,13 +235,7 @@ class Scoping:
 
             np_array = settings.get_runtime_client_config(self._server).return_arrays
         try:
-            vec = dpf_vector.DPFVectorInt(
-                client=self._server.client,
-                api=self._server.get_api_for_type(
-                    capi=dpf_vector_capi.DpfVectorCAPI,
-                    grpcapi=dpf_vector_abstract_api.DpfVectorAbstractAPI,
-                ),
-            )
+            vec = dpf_vector.DPFVectorInt(owner=self)
             self._api.scoping_get_ids_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size
             )

--- a/src/ansys/dpf/core/string_field.py
+++ b/src/ansys/dpf/core/string_field.py
@@ -201,7 +201,7 @@ class StringField(_FieldBase):
     def get_entity_data(self, index):
         """Return entity data."""
         try:
-            vec = dpf_vector.DPFVectorString(client=self._server.client)
+            vec = dpf_vector.DPFVectorString(owner=self)
             self._api.csstring_field_get_entity_data_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size, index
             )
@@ -213,7 +213,7 @@ class StringField(_FieldBase):
     def get_entity_data_by_id(self, id):
         """Return entity data corresponding to the provided id."""
         try:
-            vec = dpf_vector.DPFVectorString(client=self._server.client)
+            vec = dpf_vector.DPFVectorString(owner=self)
             self._api.csstring_field_get_entity_data_by_id_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size, id
             )
@@ -236,7 +236,7 @@ class StringField(_FieldBase):
 
     def _get_data(self, np_array=True):
         try:
-            vec = dpf_vector.DPFVectorString(client=self._server.client)
+            vec = dpf_vector.DPFVectorString(owner=self)
             self._api.csstring_field_get_data_for_dpf_vector(
                 self, vec, vec.internal_data, vec.internal_size
             )

--- a/src/ansys/dpf/gate/dpf_vector.py
+++ b/src/ansys/dpf/gate/dpf_vector.py
@@ -23,23 +23,23 @@ class DPFVectorBase:
 
     Parameters
     ----------
-    client: object having _internal_obj attribute and a shared CLayer Client instance, optional
+    owner: object having _internal_obj attribute and a shared CLayer Client instance, optional
         Enables DPFClientAPI to choose the right API to use.
 
     api: DpfVectorAbstractAPI, optional
     """
 
-    def __init__(self, client, api):
+    def __init__(self, owner, api):
         self.dpf_vector_api = api
         self._modified = False
         self._check_changes = True
         try:
-            if not client:
+            if owner is None:
                 self._internal_obj = self.dpf_vector_api.dpf_vector_new()
                 self._check_changes = False
             else:
-                self._internal_obj = self.dpf_vector_api.dpf_vector_new_for_object(client)
-        except AttributeError:
+                self._internal_obj = self.dpf_vector_api.dpf_vector_new_for_object(owner)
+        except ctypes.ArgumentError:
             raise NotImplementedError
 
     @property
@@ -140,8 +140,8 @@ class DPFVectorBase:
 
 
 class DPFVectorInt(DPFVectorBase):
-    def __init__(self, client=None, api=dpf_vector_capi.DpfVectorCAPI):
-        super().__init__(client, api)
+    def __init__(self, owner=None, api=dpf_vector_capi.DpfVectorCAPI):
+        super().__init__(owner, api)
         self._array = MutableListInt32()
 
     @property
@@ -171,8 +171,8 @@ class DPFVectorInt(DPFVectorBase):
 
 
 class DPFVectorDouble(DPFVectorBase):
-    def __init__(self, client=None, api=dpf_vector_capi.DpfVectorCAPI):
-        super().__init__(client, api)
+    def __init__(self, owner=None, api=dpf_vector_capi.DpfVectorCAPI):
+        super().__init__(owner, api)
         self._array = MutableListDouble()
 
     @property
@@ -202,9 +202,9 @@ class DPFVectorDouble(DPFVectorBase):
 
 
 class DPFVectorCustomType(DPFVectorBase):
-    def __init__(self, unitary_type, client=None, api=dpf_vector_capi.DpfVectorCAPI):
+    def __init__(self, unitary_type, owner=None, api=dpf_vector_capi.DpfVectorCAPI):
         self.type = unitary_type
-        super().__init__(client, api)
+        super().__init__(owner, api)
         self._array = MutableListChar()
 
     @property
@@ -258,8 +258,8 @@ class DPFVectorCustomType(DPFVectorBase):
 
 
 class DPFVectorString(DPFVectorBase):
-    def __init__(self, client=None, api=dpf_vector_capi.DpfVectorCAPI):
-        super().__init__(client, api)
+    def __init__(self, owner=None, api=dpf_vector_capi.DpfVectorCAPI):
+        super().__init__(owner, api)
         self._array = MutableListString()
 
     @property


### PR DESCRIPTION
When working on distributed workflows (in process and gRPC), DPFVector were sometimes created on one clayer and deleted on another. This prevented any changes in the DPFVector.