### PR TITLE
Ci: add test analytics

### DIFF
--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -231,7 +231,7 @@ jobs:
           flags: docker,${{ inputs.ANSYS_VERSION }},${{ matrix.os }},${{ matrix.python-version }}
 
       - name: "Upload test analytics results to Codecov"
-        if: startsWith(github.head_ref, 'master') || ${{ !cancelled() }}
+        if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -229,3 +229,11 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }} # required
           name: ${{ env.PACKAGE_NAME }}_${{ matrix.python-version }}_${{ matrix.os }}_pytest_${{ inputs.ANSYS_VERSION }}_docker.xml
           flags: docker,${{ inputs.ANSYS_VERSION }},${{ matrix.os }},${{ matrix.python-version }}
+
+      - name: "Upload test analytics results to Codecov"
+        if: startsWith(github.head_ref, 'master') || ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: test_results_${{ env.PACKAGE_NAME }}_${{ matrix.python-version }}_${{ matrix.os }}_${{ inputs.ANSYS_VERSION }}${{ inputs.test_any == 'true' && '_any' || '' }}
+          flags: ${{ inputs.ANSYS_VERSION }},${{ matrix.os }},${{ matrix.python-version }}${{ inputs.test_any == 'true' && ',any' || '' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -311,7 +311,7 @@ jobs:
           flags: ${{ inputs.ANSYS_VERSION }},${{ matrix.os }},${{ matrix.python-version }}${{ inputs.test_any == 'true' && ',any' || '' }}
 
       - name: "Upload test analytics results to Codecov"
-        if: startsWith(github.head_ref, 'master') || ${{ !cancelled() }}
+        if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -309,3 +309,11 @@ jobs:
           file: ./.tox/.cov/coverage.xml
           name: ${{ env.PACKAGE_NAME }}_${{ matrix.python-version }}_${{ matrix.os }}_pytest_${{ inputs.ANSYS_VERSION }}${{ inputs.test_any == 'true' && '_any' || '' }}.xml
           flags: ${{ inputs.ANSYS_VERSION }},${{ matrix.os }},${{ matrix.python-version }}${{ inputs.test_any == 'true' && ',any' || '' }}
+
+      - name: "Upload test analytics results to Codecov"
+        if: startsWith(github.head_ref, 'master') || ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: test_results_${{ env.PACKAGE_NAME }}_${{ matrix.python-version }}_${{ matrix.os }}_${{ inputs.ANSYS_VERSION }}${{ inputs.test_any == 'true' && '_any' || '' }}
+          flags: ${{ inputs.ANSYS_VERSION }},${{ matrix.os }},${{ matrix.python-version }}${{ inputs.test_any == 'true' && ',any' || '' }}

--- a/tox.ini
+++ b/tox.ini
@@ -140,18 +140,18 @@ setenv =
     DEBUG = -v -s --durations=10 --durations-min=1.0
     COVERAGE_FILE = {work_dir}/.cov/.coverage.{env_name}
 
-    api: JUNITXML = --junitxml=tests/junit/test-results.xml
-    launcher: JUNITXML = --junitxml=tests/junit/test-results2.xml
-    server: JUNITXML = --junitxml=tests/junit/test-results3.xml
-    local_server: JUNITXML = --junitxml=tests/junit/test-results4.xml
-    multi_server: JUNITXML = --junitxml=tests/junit/test-results5.xml
-    remote_workflow: JUNITXML = --junitxml=tests/junit/test-results6.xml
-    remote_operator: JUNITXML = --junitxml=tests/junit/test-results7.xml
-    workflow: JUNITXML = --junitxml=tests/junit/test-results8.xml
-    service: JUNITXML = --junitxml=tests/junit/test-results9.xml
-    api_entry: JUNITXML = --junitxml=tests/junit/test-results10.xml
-    custom_type_field: JUNITXML = --junitxml=tests/junit/test-results11.xml
-    operators: JUNITXML = --junitxml=tests/junit/test-results12.xml
+    api: JUNITXML = --junitxml=tests/junit/test-results.xml -o junit_family=legacy
+    launcher: JUNITXML = --junitxml=tests/junit/test-results2.xml -o junit_family=legacy
+    server: JUNITXML = --junitxml=tests/junit/test-results3.xml -o junit_family=legacy
+    local_server: JUNITXML = --junitxml=tests/junit/test-results4.xml -o junit_family=legacy
+    multi_server: JUNITXML = --junitxml=tests/junit/test-results5.xml -o junit_family=legacy
+    remote_workflow: JUNITXML = --junitxml=tests/junit/test-results6.xml -o junit_family=legacy
+    remote_operator: JUNITXML = --junitxml=tests/junit/test-results7.xml -o junit_family=legacy
+    workflow: JUNITXML = --junitxml=tests/junit/test-results8.xml -o junit_family=legacy
+    service: JUNITXML = --junitxml=tests/junit/test-results9.xml -o junit_family=legacy
+    api_entry: JUNITXML = --junitxml=tests/junit/test-results10.xml -o junit_family=legacy
+    custom_type_field: JUNITXML = --junitxml=tests/junit/test-results11.xml -o junit_family=legacy
+    operators: JUNITXML = --junitxml=tests/junit/test-results12.xml -o junit_family=legacy
 
     # Tests sets
     api: PYTEST_PYTHON_FILES = tests


### PR DESCRIPTION
This PR adds test result upload to Codecov to start getting test analytics (test failure rates and average duration over commits for dev branches and over time for the main branch).
This will ease identification of flaky tests and prioritization of investigations for random failures.