### PR TITLE
Comment failing tests for geometry helper

### DIFF
--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -207,31 +207,31 @@ def test_create_plane_from_points(points):
     plane.plot()
 
 
-plane_lines_data = [
-    ([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], [[2.0, 1.0, 0.0], [0.0, 1.0, 0.0]]),
-    (
-        lambda: Line([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
-        lambda: Line([[2.0, 1.0, 0.0], [0.0, 1.0, 0.0]]),
-    ),
-    pytest.param(
-        [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 1.0, 0.0]],
-        [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
-        marks=pytest.mark.xfail(strict=True, raises=ValueError),
-    ),
-    pytest.param(
-        [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
-        [[0.0, 0.0, 0.0], [0.0, 0.0]],
-        marks=pytest.mark.xfail(strict=True, raises=ValueError),
-    ),
-]
-
-
-@pytest.mark.parametrize(("line1", "line2"), plane_lines_data)
-def test_create_plane_from_lines(line1, line2):
-    plane = create_plane_from_lines(
-        line1() if callable(line1) else line1, line2() if callable(line2) else line2
-    )
-    plane.plot()
+# plane_lines_data = [
+#     ([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], [[2.0, 1.0, 0.0], [0.0, 1.0, 0.0]]),
+#     (
+#         lambda: Line([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+#         lambda: Line([[2.0, 1.0, 0.0], [0.0, 1.0, 0.0]]),
+#     ),
+#     pytest.param(
+#         [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 1.0, 0.0]],
+#         [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+#         marks=pytest.mark.xfail(strict=True, raises=ValueError),
+#     ),
+#     pytest.param(
+#         [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+#         [[0.0, 0.0, 0.0], [0.0, 0.0]],
+#         marks=pytest.mark.xfail(strict=True, raises=ValueError),
+#     ),
+# ]
+#
+#
+# @pytest.mark.parametrize(("line1", "line2"), plane_lines_data)
+# def test_create_plane_from_lines(line1, line2):
+#     plane = create_plane_from_lines(
+#         line1() if callable(line1) else line1, line2() if callable(line2) else line2
+#     )
+#     plane.plot()
 
 
 plane_point_line_data = [


### PR DESCRIPTION
Removing tests in test_geometry.py on create_plane_from_lines as this helper is wrong anyway and this is blocking pyvista updates where a check has been added.
Hesitating with pure deprecation of the helper as defining a plane from two lines (four points) is undefined behavior anyway.