### PR TITLE
ci: make pydpf-post job information-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,4 +253,5 @@ jobs:
       post_branch: "master"
       standalone_suffix: ${{needs.pick_server_suffix.outputs.suffix}}
       test_docstrings: "true"
+      continue-on-error: true
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,5 +253,4 @@ jobs:
       post_branch: "master"
       standalone_suffix: ${{needs.pick_server_suffix.outputs.suffix}}
       test_docstrings: "true"
-      continue-on-error: true
     secrets: inherit

--- a/.github/workflows/pydpf-post.yml
+++ b/.github/workflows/pydpf-post.yml
@@ -147,6 +147,7 @@ jobs:
         run: pip list
 
       - name: "Test Docstrings"
+        id: docstrings
         uses: ansys/pydpf-actions/test_docstrings@v2.3
         with:
           MODULE: post
@@ -155,8 +156,15 @@ jobs:
         if: inputs.test_docstrings == 'true'
         timeout-minutes: 10
         continue-on-error: true
+        
+      - uses: mainmatter/continue-on-error-comment@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          outcome: ${{ steps.docstrings.outcome }}
+          test-id: PyDPF-Post docstring tests on ${{ matrix.os }}
 
       - name: "Test API"
+        id: api
         shell: bash
         working-directory: pydpf-post/tests
         run: |
@@ -165,5 +173,11 @@ jobs:
         timeout-minutes: 60
         continue-on-error: true
 
+      - uses: mainmatter/continue-on-error-comment@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          outcome: ${{ steps.api.outcome }}
+          test-id: PyDPF-Post API tests on ${{ matrix.os }}
+          
       - name: "Kill all servers"
         uses: ansys/pydpf-actions/kill-dpf-servers@v2.3

--- a/.github/workflows/pydpf-post.yml
+++ b/.github/workflows/pydpf-post.yml
@@ -57,6 +57,7 @@ jobs:
       matrix:
         os: ["windows-latest", "ubuntu-latest"]
         python-version: ["3.10"]
+    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pydpf-post.yml
+++ b/.github/workflows/pydpf-post.yml
@@ -57,7 +57,6 @@ jobs:
       matrix:
         os: ["windows-latest", "ubuntu-latest"]
         python-version: ["3.10"]
-    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v4
@@ -155,6 +154,7 @@ jobs:
           working-directory: pydpf-post/src
         if: inputs.test_docstrings == 'true'
         timeout-minutes: 10
+        continue-on-error: true
 
       - name: "Test API"
         shell: bash
@@ -163,6 +163,7 @@ jobs:
           pytest $DEBUG --maxfail=5 --reruns 2 .
         if: always()
         timeout-minutes: 60
+        continue-on-error: true
 
       - name: "Kill all servers"
         uses: ansys/pydpf-actions/kill-dpf-servers@v2.3


### PR DESCRIPTION
The PyDPF-Core CI runs PyDPF-Post tests for information purposes thanks to its `pydpf-post.yml` workflow.
This PR makes sure that the workflow is always reported as successful to not stop people from merging, while still [reporting errors](https://github.com/marketplace/actions/continue-on-error-comment) for PyDPF-Post tests as comments in the PR if any.
This is most useful for `server-sync` PRs.