### PR TITLE
Fix update of empty vectors

### DIFF
--- a/src/ansys/dpf/gate/dpf_vector.py
+++ b/src/ansys/dpf/gate/dpf_vector.py
@@ -88,7 +88,7 @@ class DPFVectorBase:
         -----
         self._check_changes is set to True by default when a client is added at the class init
         """
-        return self._modified
+        return self._modified and self.size > 0 # Updating is not necessary for an empty vector. Updating it can cause issue, see #2274
 
     def __del__(self):
         try:

--- a/tests/test_dpf_vector.py
+++ b/tests/test_dpf_vector.py
@@ -19,7 +19,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
 import numpy as np
 
 from ansys.dpf import core as dpf
@@ -58,3 +57,43 @@ def test_perf_vec_getters(server_type):
     for index, chunk in enumerate(chunks):
         d = field.data[chunk]
         d = field.scoping.ids[chunk]
+
+
+def test_update_empty_dpf_vector_prop_field(server_type):
+    prop_field = dpf.PropertyField(server=server_type)
+    prop_field.data = np.zeros((100))
+    prop_field.scoping.ids = list(range(1, 100))
+    assert np.allclose(prop_field.get_entity_data(1), [0])
+    dp = prop_field._data_pointer
+    dp = None
+    assert np.allclose(prop_field.get_entity_data(1), [0])
+
+
+def test_update_empty_dpf_vector_field(server_type):
+    field = dpf.Field(server=server_type)
+    field.data = np.zeros((100), dtype=np.double)
+    field.scoping.ids = list(range(1, 100))
+    assert np.allclose(field.get_entity_data(1), [0])
+    dp = field._data_pointer
+    dp = None
+    assert np.allclose(field.get_entity_data(1), [0])
+
+
+def test_update_empty_dpf_vector_string_field(server_type):
+    string_field = dpf.StringField(server=server_type)
+    string_field.data = ["high", "goodbye", "hello"]
+    string_field.scoping.ids = list(range(1, 3))
+    assert string_field.get_entity_data(1) == ["goodbye"]
+    dp = string_field._data_pointer
+    dp = None
+    assert string_field.get_entity_data(1) == ["goodbye"]
+
+
+def test_update_empty_dpf_vector_custom_type_field(server_type):
+    field = dpf.CustomTypeField(unitary_type=np.double, server=server_type)
+    field.data = np.zeros((100), dtype=np.double)
+    field.scoping.ids = list(range(1, 100))
+    assert np.allclose(field.get_entity_data(1), [0])
+    dp = field._data_pointer
+    dp = None
+    assert np.allclose(field.get_entity_data(1), [0])


### PR DESCRIPTION
Empty (nullptr) vectors can be updated to non empty vectors of size 0 when using gRPC.
This can, for example, cause a property field to have a non empty data pointer after accessing the data pointer in python.

closing #2274