### PR TITLE
Feature: allow setting named dimensionless units in a Field

### DIFF
--- a/src/ansys/dpf/core/field.py
+++ b/src/ansys/dpf/core/field.py
@@ -640,6 +640,29 @@ class Field(_FieldBase):
         fielddef.unit = value
         self.field_definition = fielddef
 
+    def set_named_dimensionless_unit(self, value):
+        """Set a named dimensionless unit for the field.
+
+        Parameters
+        ----------
+        value : str
+            Units for the field. This unit must be homogeneous to no physical quantity
+
+        Examples
+        --------
+        Units for a psychoacoustics field.
+
+        >>> from ansys.dpf import core as dpf
+        >>> my_field = dpf.Field(10)
+        >>> my_field.set_named_dimensionless_unit("sones")
+        >>> print(my_field.unit)
+        sones
+
+        """
+        fielddef = self.field_definition
+        fielddef.set_named_dimensionless_unit(value)
+        self.field_definition = fielddef
+
     @property
     def dimensionality(self):
         """Dimensionality represents the shape of the elementary data contained in the field.

--- a/src/ansys/dpf/core/field.py
+++ b/src/ansys/dpf/core/field.py
@@ -620,9 +620,15 @@ class Field(_FieldBase):
     def unit(self, value):
         """Change the unit for the field.
 
+        If the value is a single string, then it will be interpreted to a physical meaning (homogeneity).
+
+        If the value is a tuple, then it must contain an homogeneity and a string.
+            If homogeneity is "dimensionless", then the unit string is kept as is.
+            Otherwise, homogeneity is ignored, and unit string is interpreted to a physical meaning.
+
         Parameters
         ----------
-        value : str
+        value : str | tuple(str, str)
             Units for the field.
 
         Examples
@@ -635,32 +641,18 @@ class Field(_FieldBase):
         >>> my_field.unit
         'm'
 
-        """
-        fielddef = self.field_definition
-        fielddef.unit = value
-        self.field_definition = fielddef
 
-    def set_named_dimensionless_unit(self, value):
-        """Set a named dimensionless unit for the field.
-
-        Parameters
-        ----------
-        value : str
-            Units for the field. This unit must be homogeneous to no physical quantity
-
-        Examples
-        --------
-        Units for a psychoacoustics field.
+        Named dimensionless unit.
 
         >>> from ansys.dpf import core as dpf
         >>> my_field = dpf.Field(10)
-        >>> my_field.set_named_dimensionless_unit("sones")
+        >>> my_field.unit = ("dimensionless", "dollars")
         >>> print(my_field.unit)
-        sones
+        'dollars'
 
         """
         fielddef = self.field_definition
-        fielddef.set_named_dimensionless_unit(value)
+        fielddef.unit = value
         self.field_definition = fielddef
 
     @property

--- a/src/ansys/dpf/core/field_definition.py
+++ b/src/ansys/dpf/core/field_definition.py
@@ -207,6 +207,17 @@ class FieldDefinition:
     def unit(self, value):
         self._api.csfield_definition_set_unit(self, value, None, 0, 0, 0)
 
+    def set_named_dimensionless_unit(self, value):
+        """Set a named dimensionless unit for the field.
+
+        Parameters
+        ----------
+        value : str
+            Units for the field. This unit must be homogeneous to no physical quantity
+        """
+        # 117 corresponds to dimensionless
+        self._api.csfield_definition_set_unit(self, value, None, 117, 0, 0)
+
     @location.setter
     def location(self, value):
         self._api.csfield_definition_set_location(self, value)

--- a/src/ansys/dpf/core/field_definition.py
+++ b/src/ansys/dpf/core/field_definition.py
@@ -205,18 +205,16 @@ class FieldDefinition:
 
     @unit.setter
     def unit(self, value):
-        self._api.csfield_definition_set_unit(self, value, None, 0, 0, 0)
-
-    def set_named_dimensionless_unit(self, value):
-        """Set a named dimensionless unit for the field.
-
-        Parameters
-        ----------
-        value : str
-            Units for the field. This unit must be homogeneous to no physical quantity
-        """
-        # 117 corresponds to dimensionless
-        self._api.csfield_definition_set_unit(self, value, None, 117, 0, 0)
+        # setter with explicit homogeneity: homogeneity is taken into account if it is dimensionless
+        if isinstance(value, tuple):
+            if value[0] == "dimensionless":
+                # 117 corresponds to dimensionless
+                self._api.csfield_definition_set_unit(self, value[1], None, 117, 0, 0)
+            else:
+                self._api.csfield_definition_set_unit(self, value[1], None, 0, 0, 0)
+        # standard unit setter, using string interpreter
+        else:
+            self._api.csfield_definition_set_unit(self, value, None, 0, 0, 0)
 
     @location.setter
     def location(self, value):

--- a/tests/entry/conftest.py
+++ b/tests/entry/conftest.py
@@ -71,6 +71,9 @@ if running_docker:
         "/tmp/test_files"
     )
 
+SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0 = meets_version(
+    get_server_version(core._global_server()), "10.0"
+)
 SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_8_1 = meets_version(
     get_server_version(core._global_server()), "8.1"
 )

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -32,7 +32,11 @@ from ansys.dpf.core import FieldDefinition, operators as ops
 from ansys.dpf.core.check_version import server_meet_version
 from ansys.dpf.core.common import locations, shell_layers
 import conftest
-from conftest import SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_8_0, running_docker
+from conftest import (
+    SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_8_0,
+    SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0,
+    running_docker,
+)
 
 
 @pytest.fixture()
@@ -1417,3 +1421,16 @@ def test_deep_copy_big_field_remote(server_type, server_type_remote_process):
 
     out = dpf.core.core._deep_copy(field_a, server_type_remote_process)
     assert np.allclose(out.data, data)
+
+
+@pytest.mark.skipif(
+    not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0, reason="Available for servers >=10.0"
+)
+def test_set_named_dimensionless_units():
+    data = np.random.random(100)
+    field = dpf.core.field_from_array(data)
+    field.unit = "m"
+    assert field.unit == "m"
+
+    field.set_named_dimensionless_unit("sones")
+    assert field.unit == "sones"

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1426,11 +1426,14 @@ def test_deep_copy_big_field_remote(server_type, server_type_remote_process):
 @pytest.mark.skipif(
     not SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_10_0, reason="Available for servers >=10.0"
 )
-def test_set_named_dimensionless_units():
+def test_set_units():
     data = np.random.random(100)
     field = dpf.core.field_from_array(data)
     field.unit = "m"
     assert field.unit == "m"
 
-    field.set_named_dimensionless_unit("sones")
+    field.unit = ("dimensionless", "sones")
     assert field.unit == "sones"
+
+    with pytest.raises(Exception):
+        field.unit = "sones"


### PR DESCRIPTION
Following the addition of a new Unit ctor on server side, we propose to add the same option on client side:
Field.unit can now be set with a dimensionless (not homogeneous to anything) unit, with a custom name.
Usefull especially for pyAnsys Sound, where lots of "psychoacoustic" units are dimensionless and named.