### PR TITLE
Support Beam3 in ElementDescriptor

### DIFF
--- a/src/ansys/dpf/core/elements.py
+++ b/src/ansys/dpf/core/elements.py
@@ -1219,7 +1219,9 @@ class element_types(Enum):
             ),
             element_types.Edge2: ElementDescriptor(element_types.Edge2, "Edge2", "edge2", "beam"),
             element_types.Edge3: ElementDescriptor(element_types.Edge3, "Edge3", "edge3", "beam"),
-            element_types.Beam3: ElementDescriptor(element_types.Beam3, "Beam3", "beam3", "beam"),
+            element_types.Beam3: ElementDescriptor(
+                element_types.Beam3, "Beam3", "beam3", "beam", 2, 0, 3, False, False, True, False
+            ),
             element_types.Beam4: ElementDescriptor(element_types.Beam4, "Beam4", "beam4", "beam"),
             element_types.GeneralPlaceholder: ElementDescriptor(
                 element_types.GeneralPlaceholder,

--- a/src/ansys/dpf/core/elements.py
+++ b/src/ansys/dpf/core/elements.py
@@ -1219,9 +1219,7 @@ class element_types(Enum):
             ),
             element_types.Edge2: ElementDescriptor(element_types.Edge2, "Edge2", "edge2", "beam"),
             element_types.Edge3: ElementDescriptor(element_types.Edge3, "Edge3", "edge3", "beam"),
-            element_types.Beam3: ElementDescriptor(
-                element_types.Beam3, "Beam3", "beam3", "beam", 2, 0, 3, False, False, True, False
-            ),
+            element_types.Beam3: ElementDescriptor(element_types.Beam3, "Beam3", "beam3", "beam"),
             element_types.Beam4: ElementDescriptor(element_types.Beam4, "Beam4", "beam4", "beam"),
             element_types.GeneralPlaceholder: ElementDescriptor(
                 element_types.GeneralPlaceholder,

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -767,13 +767,13 @@ def test_beam3():
         "Beam3",
         "beam3",
         "beam",
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
+        2,
+        0,
+        3,
+        False,
+        False,
+        True,
+        False,
     )
 
 


### PR DESCRIPTION
Properly support the number of nodes, number of corner nodes and nmber of quadratic nodes in the Beam3 ElementDescriptor