### PR TITLE
fix(dependencies): Remove upper limit on imageio in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ graphics = [
     "pyvista>=0.32.0",
     "vtk!=9.4.0",
     # Animations
-    "imageio < 2.28.1",
+    "imageio",
     "imageio-ffmpeg",
 ]
 
@@ -56,7 +56,7 @@ plotting = [
     "pyvista>=0.32.0",
     "vtk",
     # Animations
-    "imageio < 2.28.1",
+    "imageio",
     "imageio-ffmpeg",
 ]
 


### PR DESCRIPTION
Fixes #2308 

For some reason `imageio` was still limited to `2.28.0` in `pyproject.toml` despite requirement files testing for the latest.

This resulted in the bug linked above.