### PR TITLE
Supporting Heterogeneous operating system file path of results file

### DIFF
--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -25,7 +25,7 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
+from pathlib import Path, PurePath
 import traceback
 from typing import TYPE_CHECKING, Union
 import warnings
@@ -159,7 +159,7 @@ class DataSources:
         ['...tmp...file.rst']
 
         """
-        filepath = Path(filepath)
+        filepath = Path(filepath) if not isinstance(filepath, PurePath) else filepath
         extension = filepath.suffix
         # Handle .res files from CFX
         if key == "" and extension == ".res":
@@ -290,7 +290,7 @@ class DataSources:
         >>> my_data_sources.set_domain_result_file_path(path='/tmp/file1.rst', key='rst', domain_id=1)
 
         """
-        path = Path(path)
+        path = Path(path) if not isinstance(path, PurePath) else path
         if key:
             self._api.data_sources_set_domain_result_file_path_with_key_utf8(
                 self, str(path), key, domain_id
@@ -341,7 +341,7 @@ class DataSources:
         # The filename needs to be a fully qualified file name
         # if not os.path.dirname(filepath)
 
-        filepath = Path(filepath)
+        filepath = Path(filepath) if not isinstance(filepath, PurePath) else filepath
         if not filepath.parent.name:
             # append local path
             filepath = Path.cwd() / filepath.name
@@ -391,7 +391,7 @@ class DataSources:
 
         """
         # The filename needs to be a fully qualified file name
-        filepath = Path(filepath)
+        filepath = Path(filepath) if not isinstance(filepath, PurePath) else filepath
         if not filepath.parent.name:
             # append local path
             filepath = Path.cwd() / filepath.name
@@ -424,7 +424,7 @@ class DataSources:
             The default is ``""``, in which case the key is found directly.
         """
         # The filename needs to be a fully qualified file name
-        filepath = Path(filepath)
+        filepath = Path(filepath) if not isinstance(filepath, PurePath) else filepath
         if not filepath.parent.name:
             # append local path
             filepath = Path.cwd() / filepath.name

--- a/src/ansys/dpf/core/model.py
+++ b/src/ansys/dpf/core/model.py
@@ -429,11 +429,11 @@ class Metadata:
         return self._stream_provider
 
     def _set_data_sources(self, var_inp):
-        from pathlib import Path
+        from pathlib import PurePath
 
         if isinstance(var_inp, dpf.core.DataSources):
             self._data_sources = var_inp
-        elif isinstance(var_inp, (str, Path)):
+        elif isinstance(var_inp, (str, PurePath)):
             self._data_sources = DataSources(var_inp, server=self._server)
         else:
             self._data_sources = DataSources(server=self._server)


### PR DESCRIPTION
This PR enable support for heterogeneous path type which is required while doing remote post processing.

Recommendation for defining file path to perform post processing on remote linux machine would be:

```
from ansys.dpf import core as dpf
from pathlib import PurePosixPath

server = dpf.connect_to_server(ip='xxxxxxxx',port=50052)

# Create a Path object for a Linux-style file path
linux_file = PurePosixPath("/nfs/scratch1/ACE/rmeena/file.rst")

ds = dpf.DataSources(server=server, result_path=linux_file)

model = dpf.Model(data_sources=ds, server=server)

# optionally, Model class can take path directly as well.
# model = dpf.Model(data_sources=linux_file, server=server)

print(model) 
```