### PR TITLE
Add a readme file to the "mathematical_operations_examples" folder

### DIFF
--- a/examples/01-mathematical-operations/README.txt
+++ b/examples/01-mathematical-operations/README.txt
@@ -1,0 +1,6 @@
+.. _mathematical_operations_examples:
+
+Mathematical examples
+=====================
+
+These examples show how to do mathematical operations with PyDPF-Core structures.


### PR DESCRIPTION
Add a readme file to the "mathematical_operations_examples" folder so the math operations section is displayed on the documentation 