### PR TITLE
ci: test 25R2 retro-compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,7 @@ jobs:
       fail-fast: false
       matrix:
         dpf:
+          - {"version": "252", "standalone-suffix": ""}
           - {"version": "251", "standalone-suffix": ""}
           - {"version": "242", "standalone-suffix": ""}
           - {"version": "241", "standalone-suffix": ".sp01"}


### PR DESCRIPTION
Adds back 25R2 to retro testing following its removal by https://github.com/ansys/pydpf-core/pull/2292