### PR TITLE
fix: custom type check for unsupported type

### DIFF
--- a/src/ansys/dpf/core/custom_type_field.py
+++ b/src/ansys/dpf/core/custom_type_field.py
@@ -64,6 +64,8 @@ class CustomTypeField(_FieldBase):
     The ``CustomTypeField`` class gives you the ability to choose the most optimized unitary
     data type for a given usage, and hence, allows you to optimize memory usage.
 
+    The unitary data type must have an equivalent ctype (check this with ``np.ctypeslib.as_ctypes_type``).
+
     This can be evaluated data from the :class:`Operator <ansys.dpf.core.Operator>` class
     or created directly by an instance of this class.
 
@@ -75,6 +77,7 @@ class CustomTypeField(_FieldBase):
     ----------
     unitary_type : numpy.dtype
         The data vector of the Field will be a vector of this custom unitary type.
+        This dtype must have an equivalent ctype (check this with ``np.ctypeslib.as_ctypes_type``).
     nentities : int, optional
         Number of entities reserved. The default is ``0``.
     field : CustomTypeField, ansys.grpc.dpf.field_pb2.Field, ctypes.c_void_p, optional
@@ -118,6 +121,13 @@ class CustomTypeField(_FieldBase):
             raise errors.DpfVersionNotSupported("5.0")
         if unitary_type is not None:
             self._type = np.dtype(unitary_type)
+            try:
+                # Check the type can be converted to a ctype
+                np.ctypeslib.as_ctypes_type(self._type)
+            except NotImplementedError as e:
+                raise ValueError(
+                    f"CustomTypeField: invalid unitary_type {self._type} (numpy: NotImplementedError: {e})."
+                )
         else:
             self._type = unitary_type
         super().__init__(nentities=nentities, field=field, server=server)

--- a/src/ansys/dpf/gate/dpf_vector.py
+++ b/src/ansys/dpf/gate/dpf_vector.py
@@ -164,6 +164,13 @@ class DPFVectorDouble(DPFVectorBase):
 class DPFVectorCustomType(DPFVectorBase):
     def __init__(self, unitary_type, owner=None, api=dpf_vector_capi.DpfVectorCAPI):
         self.type = unitary_type
+        try:
+            # Check the type can be converted to a ctype
+            np.ctypeslib.as_ctypes_type(self.type)
+        except NotImplementedError as e:
+            raise ValueError(
+                f"DPFVectorCustomType: invalid unitary_type {self.type} (numpy: NotImplementedError: {e})."
+            )
         super().__init__(owner, api)
         self._array = MutableListChar()
 

--- a/tests/test_custom_type_field.py
+++ b/tests/test_custom_type_field.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 import numpy as np
+import pytest
 
 from ansys import dpf
 from ansys.dpf import core
@@ -281,6 +282,9 @@ def test_check_types_custom_type_field(server_type):
     pfield3 = core.CustomTypeField(np.float32, server=server_type)
     pfield4 = core.CustomTypeField(np.float64, server=server_type)
     pfield5 = core.CustomTypeField(np.int8, server=server_type)
+
+    with pytest.raises(ValueError, match="CustomTypeField: invalid unitary_type"):
+        _ = core.CustomTypeField(np.complex128, server=server_type)
 
     forward = dpf.core.operators.utility.forward(server=server_type)
     forward.connect(0, pfield)

--- a/tests/test_dpf_vector.py
+++ b/tests/test_dpf_vector.py
@@ -24,6 +24,7 @@ import pytest
 
 from ansys.dpf import core as dpf
 from ansys.dpf.core import fields_factory
+from ansys.dpf.gate.dpf_vector import DPFVectorCustomType
 import conftest
 
 
@@ -104,3 +105,8 @@ def test_update_empty_dpf_vector_custom_type_field(server_type):
     dp = field._data_pointer
     dp = None
     assert np.allclose(field.get_entity_data(1), [0])
+
+
+def test_invalid_unitary_type_dpf_vector_custom_type(server_type):
+    with pytest.raises(ValueError, match="DPFVectorCustomType: invalid unitary_type"):
+        DPFVectorCustomType(unitary_type=np.complex128)


### PR DESCRIPTION
Solves #2405 by raising an error at creation of a custom type entity (`CustomTypeField` or `DPFVectorCustomType`) if the type is not convertible to a `ctype`.