### PR TITLE
fix(plotter): merge fields of fields_container before plot

### DIFF
--- a/src/ansys/dpf/core/fields_container.py
+++ b/src/ansys/dpf/core/fields_container.py
@@ -547,8 +547,12 @@ class FieldsContainer(CollectionBase["field.Field"]):
         if label_space is None:
             label_space = {}
         fields = self.get_fields(label_space=label_space)
-        for f in fields:
-            plt.add_field(field=f, **kwargs)
+        # Fields with same support will override each other so we first merge them
+        merge_op = dpf.core.operators.utility.merge_fields()
+        for i, f in enumerate(fields):
+            merge_op.connect(i, f)
+        merged_field = merge_op.eval()
+        plt.add_field(field=merged_field, **kwargs)
         plt.show_figure(**kwargs)
 
     def animate(


### PR DESCRIPTION
As the `Plotter.add_field` method overrides data for fields with overlapping scoping, we merge the fields in `FieldsContainer.plot()` before the call to `add_field`.

The previous plots for a FieldContainer with several meshes with the same support were wrong and only showed the data of the last field.