### PR TITLE
ci(doc): do not deploy PR doc if doc job is skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
     name: "Deploy PR documentation"
     runs-on: ubuntu-latest
     needs: docs
-    if: always() && (needs.docs.result == 'success' || needs.docs.result == 'skipped')
+    if: always() && (needs.docs.result == 'success')
     steps:
       - uses: ansys/actions/doc-deploy-pr@v10
         with:


### PR DESCRIPTION
Hi @moe-ad I think I followed the pyansys documentation to implement thsi deploy_pr action but now I think that the conditional on the `needs.doc.result == skipped` is wrong. We should only deploy if the doc generation job was a success.
Otherwise there may be a use-case I am not seeing.