### PR TITLE
docs: fix image link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The data in DPF is defined based on physics-agnostic mathematical quantities
 described in self-sufficient entities called **fields**. This allows DPF to be 
 a modular and easy-to-use tool with a large range of capabilities.
 
-![DPF flow](https://github.com/ansys/pydpf-core/raw/main/doc/source/images/drawings/dpf-flow.png "DPF flow")
+![DPF flow](https://github.com/ansys/pydpf-core/raw/master/doc/source/images/drawings/dpf-flow.png "DPF flow")
 
 The ``ansys.dpf.core`` package provides a Python interface to DPF, enabling
 rapid postprocessing of a variety of Ansys file formats and physics solutions


### PR DESCRIPTION
I would recommend to use `main` as default branch. In the meantime, the doc can be fixed by pointing to the current default (`master`). 