### PR TITLE
fix(example): fix retro with 25R1 and below for 00-basic_plotting.py

### DIFF
--- a/examples/06-plotting/00-basic_plotting.py
+++ b/examples/06-plotting/00-basic_plotting.py
@@ -36,6 +36,7 @@ from ansys.dpf.core import examples
 
 # Plot the bare mesh of a model
 model = dpf.Model(examples.find_multishells_rst())
+print(model)
 model.plot(color="w", show_edges=True, title="Model", text="Model plot")
 # # Additional PyVista kwargs are supported, such as:
 model.plot(
@@ -55,6 +56,9 @@ model.plot(
 
 # Plot a field on its supporting mesh
 stress = model.results.stress()
+# We request the stress as nodal to bypass a bug for DPF 2025 R1 and below
+# which prevents from plotting ElementalNodal data on shells
+stress.inputs.requested_location.connect(dpf.locations.nodal)
 fc = stress.outputs.fields_container()
 field = fc[0]
 field.plot(notebook=False, shell_layers=None, show_axes=True, title="Field", text="Field plot")


### PR DESCRIPTION
Due to #511 and a bug preventing from plotting ElementalNodal results on shells for DPF 25R1 and below.