### PR TITLE
doc(tutorials): Correct card of the "Custom operators" tutorial

### DIFF
--- a/doc/source/user_guide/tutorials/custom_operators_and_plugins/index.rst
+++ b/doc/source/user_guide/tutorials/custom_operators_and_plugins/index.rst
@@ -37,13 +37,13 @@ For comprehensive examples on writing operator plugins, see :ref:`python_operato
     :margin: 2
 
     .. grid-item-card:: Create a DPF plugin with a single operator
-        :link: tutorials_custom_operators_and_plugins_custom_operator
-        :link-type: ref
-        :text-align: center
-        :class-header: sd-bg-light sd-text-dark
-        :class-footer: sd-bg-light sd-text-dark
+       :link: tutorials_custom_operators_and_plugins_custom_operator
+       :link-type: ref
+       :text-align: center
+       :class-header: sd-bg-light sd-text-dark
+       :class-footer: sd-bg-light sd-text-dark
 
-        This tutorial shows how to create, load, and use a custom plugin containing a single custom operator.
+       This tutorial shows how to create, load, and use a custom plugin containing a single custom operator.
 
        +++
        Requires DPF 7.1 or above (2024 R1).


### PR DESCRIPTION
This PR corrects how the card of the "Custom operators" tutorial  renders on the "Custom Operators and Plugins" tutorial section
Before: 

<img width="1086" height="701" alt="image" src="https://github.com/user-attachments/assets/794f893e-67e6-4b61-8aca-1d3d0b317974" />

After:

<img width="1064" height="269" alt="image" src="https://github.com/user-attachments/assets/c782fb64-da0e-4138-9abd-218c4154890d" />
