### PR TITLE
ci: use repository variables for retro testing matrices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
     secrets: inherit
 
   tests-retro:
-    name: "Test DPF ${{ matrix.dpf.version }} compatibility"
+    name: "Test DPF ${{ matrix.version }} compatibility"
     if: |
       github.event.action != 'closed' &&
       (github.event.action != 'labeled' || github.event.label.name == 'deploy-pr-doc') &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,20 +236,12 @@ jobs:
         version:
           - ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
           - ${{ fromJson(vars.ANSYS_VERSION_LAST_RELEASED) }}
-        standalone-suffix:
-          - ""
-        include:
-          - version: "241"
-          - standalone-suffix: ".sp01"
-        exclude:
-          - version: "241"
-          - standalone-suffix: ""
     uses: ./.github/workflows/tests.yml
     with:
       ANSYS_VERSION: ${{ matrix.version }}
       python_versions: '["3.10"]'
       DOCSTRING: false
-      standalone_suffix: ${{ matrix.standalone-suffix }}
+      standalone_suffix: ${{ matrix.version == '241' && '.sp01' || '' }}
     secrets: inherit
 
   sync-main-with-master:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,20 +233,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dpf:
-          - {"version": "252", "standalone-suffix": ""}
-          - {"version": "251", "standalone-suffix": ""}
-          - {"version": "242", "standalone-suffix": ""}
-          - {"version": "241", "standalone-suffix": ".sp01"}
-          - {"version": "232", "standalone-suffix": ""}
-          - {"version": "231", "standalone-suffix": ""}
-          - {"version": "222", "standalone-suffix": ""}
+        version:
+          - ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
+        standalone-suffix:
+          - ""
+        include:
+          - version: "241"
+          - standalone-suffix: ".sp01"
+        exclude:
+          - version: "241"
+          - standalone-suffix: ""
     uses: ./.github/workflows/tests.yml
     with:
-      ANSYS_VERSION: ${{ matrix.dpf.version }}
+      ANSYS_VERSION: ${{ matrix.version }}
       python_versions: '["3.10"]'
       DOCSTRING: false
-      standalone_suffix: ${{ matrix.dpf.standalone-suffix }}
+      standalone_suffix: ${{ matrix.standalone-suffix }}
     secrets: inherit
 
   sync-main-with-master:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,7 @@ jobs:
       matrix:
         version:
           - ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
+          - ${{ fromJson(vars.ANSYS_VERSION_LAST_RELEASED) }}
         standalone-suffix:
           - ""
         include:

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -132,20 +132,12 @@ jobs:
       matrix:
         version:
           - ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
-        standalone-suffix:
-          - ""
-        include:
-          - version: "241"
-            standalone-suffix: ".sp01"
-        exclude:
-          - version: "241"
-            standalone-suffix: ""
     uses: ./.github/workflows/tests.yml
     with:
       ANSYS_VERSION: ${{ matrix.version }}
       python_versions: '["3.10"]'
       DOCSTRING: false
-      standalone_suffix: ${{ matrix.standalone-suffix }}
+      standalone_suffix: ${{ matrix.version == '241' && '.sp01' || '' }}
     secrets: inherit
 
   tests-pydpf-post:
@@ -155,23 +147,18 @@ jobs:
       matrix:
         version:
           - ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
-        standalone-suffix:
+        standalone_suffix:
           - ""
         test_docstrings:
           - "false"
         include:
           - version: ${{ vars.ANSYS_VERSION_LAST_RELEASED }}
-            standalone-suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
+            standalone_suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
             test_docstrings": "true"
-          - version: "241"
-            standalone-suffix: ".sp01"
-        exclude:
-          - version: "241"
-            standalone-suffix: ""
     uses: ./.github/workflows/pydpf-post.yml
     with:
       ANSYS_VERSION: ${{ matrix.version }}
-      standalone_suffix: ${{ matrix.standalone-suffix }}
+      standalone_suffix: ${{ matrix.version == '241' && '.sp01' || matrix.standalone_suffix }}
       test_docstrings: ${{ matrix.test_docstrings }}
     secrets: inherit
 

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -130,19 +130,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dpf:
-          - {"version": "251", "standalone-suffix": ""}
-          - {"version": "242", "standalone-suffix": ""}
-          - {"version": "241", "standalone-suffix": ".sp01"}
-          - {"version": "232", "standalone-suffix": ""}
-          - {"version": "231", "standalone-suffix": ""}
-          - {"version": "222", "standalone-suffix": ""}
+        version:
+          - ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
+        standalone-suffix:
+          - ""
+        include:
+          - version: "241"
+            standalone-suffix: ".sp01"
+        exclude:
+          - version: "241"
+            standalone-suffix: ""
     uses: ./.github/workflows/tests.yml
     with:
-      ANSYS_VERSION: ${{ matrix.dpf.version }}
+      ANSYS_VERSION: ${{ matrix.version }}
       python_versions: '["3.10"]'
       DOCSTRING: false
-      standalone_suffix: ${{ matrix.dpf.standalone-suffix }}
+      standalone_suffix: ${{ matrix.standalone-suffix }}
     secrets: inherit
 
   tests-pydpf-post:
@@ -150,19 +153,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dpf:
-          - {"version": "252", "standalone-suffix": "${{ github.event.inputs.standalone_branch_suffix || '' }}", "test_docstrings": "true"}
-          - {"version": "251", "standalone-suffix": "", "test_docstrings": "false"}
-          - {"version": "242", "standalone-suffix": "", "test_docstrings": "false"}
-          - {"version": "241", "standalone-suffix": "", "test_docstrings": "false"}
-          - {"version": "232", "standalone-suffix": "", "test_docstrings": "false"}
-          - {"version": "231", "standalone-suffix": "", "test_docstrings": "false"}
-          - {"version": "222", "standalone-suffix": "", "test_docstrings": "false"}
+        version:
+          - ${{ fromJson(vars.ANSYS_VERSIONS_RETRO) }}
+        standalone-suffix:
+          - ""
+        test_docstrings:
+          - "false"
+        include:
+          - version: ${{ vars.ANSYS_VERSION_LAST_RELEASED }}
+            standalone-suffix: ${{ github.event.inputs.standalone_branch_suffix || '' }}
+            test_docstrings": "true"
+          - version: "241"
+            standalone-suffix: ".sp01"
+        exclude:
+          - version: "241"
+            standalone-suffix: ""
     uses: ./.github/workflows/pydpf-post.yml
     with:
-      ANSYS_VERSION: ${{ matrix.dpf.version }}
-      standalone_suffix: ${{ matrix.dpf.standalone-suffix }}
-      test_docstrings: ${{ matrix.dpf.test_docstrings }}
+      ANSYS_VERSION: ${{ matrix.version }}
+      standalone_suffix: ${{ matrix.standalone-suffix }}
+      test_docstrings: ${{ matrix.test_docstrings }}
     secrets: inherit
 
   docker_tests:

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -126,7 +126,7 @@ jobs:
     secrets: inherit
 
   tests-retro:
-    name: "Test DPF ${{ matrix.dpf.version }} compatibility"
+    name: "Test DPF ${{ matrix.version }} compatibility"
     strategy:
       fail-fast: false
       matrix:
@@ -141,7 +141,7 @@ jobs:
     secrets: inherit
 
   tests-pydpf-post:
-    name: "Test PyDPF-Post with ${{ matrix.dpf.version}}"
+    name: "Test PyDPF-Post with ${{ matrix.version}}"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR makes the retro job in ci.yml run for versions in repository variables ANSYS_VERSIONS_RETRO and ANSYS_VERSION_LAST_RELEASED, as well as makes the retro job in ci_release.yml run for versions in repository variable ANSYS_VERSIONS_RETRO.