### PR TITLE
ci(doc): Switch doc-deploy-pr to a dedicated workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, closed, labeled]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches-ignore:
       - '*no-ci*'
   push:
@@ -31,16 +31,14 @@ env:
 jobs:
   debug:
     runs-on: ubuntu-latest
-    if: github.event.action != 'closed'
     steps:
-    - name: Show the Github context for the triggered event
+    - name: Show the GitHub context for the triggered event
       run: echo "$GITHUB_CONTEXT"
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
 
   pick_server_suffix:
     runs-on: ubuntu-latest
-    if: github.event.action != 'closed' && (github.event.action != 'labeled' || github.event.label.name == 'deploy-pr-doc')
     outputs:
       suffix: ${{ steps.step1.outputs.suffix }}
     steps:
@@ -71,7 +69,6 @@ jobs:
   style:
     name: "Style Check"
     runs-on: ubuntu-latest
-    if: github.event.action != 'closed' && (github.event.action != 'labeled' || github.event.label.name == 'deploy-pr-doc')
     steps:
       - uses: ansys/actions/code-style@v8
         with:
@@ -80,7 +77,6 @@ jobs:
   build_linux1:
     name: "Build linux1 wheel"
     runs-on: ubuntu-latest
-    if: github.event.action != 'closed' && (github.event.action != 'labeled' || github.event.label.name == 'deploy-pr-doc')
     steps:
       - uses: actions/checkout@v4
 
@@ -111,7 +107,6 @@ jobs:
       matrix:
         test-any: ['false', 'true']
     uses: ./.github/workflows/tests.yml
-    if: github.event.action != 'closed' && (github.event.action != 'labeled' || github.event.label.name == 'deploy-pr-doc')
     needs: pick_server_suffix
     with:
       ANSYS_VERSION: ${{ inputs.ansys_version || vars.ANSYS_VERSION_DEFAULT }}
@@ -126,7 +121,6 @@ jobs:
   docker_tests:
     name: "Build and Test on Docker"
     uses: ./.github/workflows/test_docker.yml
-    if: github.event.action != 'closed' && (github.event.action != 'labeled' || github.event.label.name == 'deploy-pr-doc')
     needs: pick_server_suffix
     with:
       ANSYS_VERSION: ${{ inputs.ansys_version || vars.ANSYS_VERSION_DEFAULT }}
@@ -136,7 +130,6 @@ jobs:
   docker_examples:
     name: "Run examples on Docker"
     uses: ./.github/workflows/examples_docker.yml
-    if: github.event.action != 'closed' && (github.event.action != 'labeled' || github.event.label.name == 'deploy-pr-doc')
     needs: pick_server_suffix
     with:
       ANSYS_VERSION: ${{ inputs.ansys_version || vars.ANSYS_VERSION_DEFAULT }}
@@ -146,8 +139,6 @@ jobs:
 
   docs:
     if: |
-      github.event.action != 'closed' &&
-      (github.event.action != 'labeled' || github.event.label.name == 'deploy-pr-doc') &&
       (startsWith(github.head_ref, 'main') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft)
     uses: ./.github/workflows/docs.yml
     needs: pick_server_suffix
@@ -158,31 +149,9 @@ jobs:
       python_version: "3.11"
     secrets: inherit
 
-  doc-deploy-pr:
-    name: "Deploy PR documentation"
-    runs-on: ubuntu-latest
-    needs: docs
-    if: |
-      always() &&
-      github.event.pull_request.draft != true &&
-      (needs.docs.result == 'success' || needs.docs.result == 'skipped') &&
-      contains(github.event.pull_request.labels.*.name, 'deploy-pr-doc')
-    steps:
-      - uses: ansys/actions/doc-deploy-pr@v10
-        with:
-          cname: ${{ env.DOCUMENTATION_CNAME }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          doc-artifact-name: HTML-doc-ansys-dpf-core.zip
-          decompress-artifact: true
-          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
-          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
-          maximum-pr-doc-deployments: 10
-
   upload-development-docs:
     runs-on: ubuntu-latest
     if: |
-      github.event.action != 'closed' &&
-      (github.event.action != 'labeled' || github.event.label.name == 'deploy-pr-doc') &&
       (github.ref == 'refs/heads/main' && github.event_name == 'push')
     needs: [docs]
     steps:
@@ -198,8 +167,6 @@ jobs:
 
   examples:
     if: |
-      github.event.action != 'closed' &&
-      (github.event.action != 'labeled' || github.event.label.name == 'deploy-pr-doc') &&
       (startsWith(github.head_ref, 'main') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft)
     uses: ./.github/workflows/examples.yml
     needs: pick_server_suffix
@@ -212,8 +179,6 @@ jobs:
   pydpf-post:
     name: "PyDPF-Post"
     if: |
-      github.event.action != 'closed' &&
-      (github.event.action != 'labeled' || github.event.label.name == 'deploy-pr-doc') &&
       (startsWith(github.head_ref, 'main') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft)
     uses: ./.github/workflows/pydpf-post.yml
     needs: pick_server_suffix
@@ -227,8 +192,6 @@ jobs:
   tests-retro:
     name: "Test DPF ${{ matrix.version }} compatibility"
     if: |
-      github.event.action != 'closed' &&
-      (github.event.action != 'labeled' || github.event.label.name == 'deploy-pr-doc') &&
       (startsWith(github.head_ref, 'main') || github.event.action == 'ready_for_review' || !github.event.pull_request.draft)
     strategy:
       fail-fast: false

--- a/.github/workflows/doc-deploy-pr.yml
+++ b/.github/workflows/doc-deploy-pr.yml
@@ -1,0 +1,46 @@
+name: doc-deploy-PR
+
+on:
+  workflow_run:
+    workflows: [docs]
+    types: [completed]
+
+env:
+  DOCUMENTATION_CNAME: 'dpf.docs.pyansys.com'
+
+jobs:
+  debug:
+    name: debug
+    runs-on: ubuntu-latest
+    env:
+      EVENT_OBJ:  ${{ toJson(github.event) }}
+    steps:
+        - run: echo $EVENT_OBJ
+  doc-deploy-pr:
+    name: "Deploy PR documentation"
+    runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      contains(github.event.workflow_run.pull_requests.*.labels.*.name, 'deploy-pr-doc')
+    steps:
+      - name: "Download artifacts"
+        uses: dawidd6/action-download-artifact@v11
+        with:
+          workflow: docs.yml
+          name: HTML-doc-ansys-dpf-core.zip
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
+
+
+      - name: "Display downloaded files"
+        run: ls -R
+
+      - uses: ansys/actions/doc-deploy-pr@v10
+        with:
+          cname: ${{ env.DOCUMENTATION_CNAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          doc-artifact-name: HTML-doc-ansys-dpf-core.zip
+          decompress-artifact: true
+          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
+          maximum-pr-doc-deployments: 10


### PR DESCRIPTION
Moves the `doc-deploy-pr` action to a dedicated workflow triggered by a `workflow_run` `completed` on `docs.yml`, and deploying only if the PR is labeled with `deploy-pr-doc`.
The new workflow needs to be present in the main branch to be triggered.