### PR TITLE
Convert "displacement" to "modal_coordinate" - Part 2

### DIFF
--- a/examples/07-distributed-post/03-distributed-msup_expansion_steps.py
+++ b/examples/07-distributed-post/03-distributed-msup_expansion_steps.py
@@ -181,8 +181,7 @@ merge_fields = ops.utility.merge_fields_containers()
 merge_mesh = ops.utility.merge_meshes()
 
 ds = dpf.DataSources(files_rfrq[0])
-response = ops.result.displacement(data_sources=ds)
-response.inputs.mesh(merge_mesh.outputs.merges_mesh)
+response = ops.result.modal_coordinate(data_sources=ds)
 
 ds = dpf.DataSources(files_rfrq[1])
 response2 = ops.result.modal_coordinate(data_sources=ds)


### PR DESCRIPTION
In my last PR of correction, I missed transforming one of the operators "displacement" to "modal_coordinate". 