### PR TITLE
doc(dpf): A the "build local documentation" section to the toc_template.j2 for DPF doc generation

### DIFF
--- a/src/ansys/dpf/core/documentation/toc_template.j2
+++ b/src/ansys/dpf/core/documentation/toc_template.j2
@@ -18,6 +18,8 @@
     href: user-guide/using-operators.md
   - name: Workflow examples for beginners
     href: user-guide/workflow-examples.md
+  - name: Build local documentation
+    href: user-guide/dpf-docs-local-preview.md
 - name: Core concepts
   items:
   - name: Available types


### PR DESCRIPTION
Requires https://github.com/ansys/DevRelDocs/pull/230