### PR TITLE
fix: keep import of ServerBase in server.py

### DIFF
--- a/src/ansys/dpf/core/server.py
+++ b/src/ansys/dpf/core/server.py
@@ -48,7 +48,13 @@ from ansys.dpf.core.server_factory import (
     ServerConfig,
     ServerFactory,
 )
-from ansys.dpf.core.server_types import DPF_DEFAULT_PORT, LOCALHOST, RUNNING_DOCKER, AnyServerType
+from ansys.dpf.core.server_types import (
+    DPF_DEFAULT_PORT, 
+    LOCALHOST, 
+    RUNNING_DOCKER, 
+    ServerBase, 
+    AnyServerType,
+)
 
 
 def shutdown_global_server():


### PR DESCRIPTION
This was removed during of modification of typing but should be kept for backward compatibility of imports.