### PR TITLE
chore: remove `setuptools` as a direct dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: PyAnsys Vulnerability check (on ${{ github.ref == 'refs/heads/main' && 'main' || 'dev mode' }})
         uses: ansys/actions/check-vulnerabilities@7e89e00c5619374a1da8c2e876309d8b15ff0559 # v11.0.3
         with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          python-version: "3.12"
           python-package-name: "ansys-dpf-core"
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           dev-mode: ${{ github.ref != 'refs/heads/main' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "packaging",
     "protobuf",
     "psutil",
-    "setuptools >=83.0.0",
     "tqdm"
 ]
 


### PR DESCRIPTION
`setuptools` was added as a package dependency in #785, however, `pkg_resources` is not longer being used anywhere in the library. It should be fine to remove `setuptools` as a dependency now.