### PR TITLE
fix: Make __del__ methods shutdown-safe for DPF objects

### DIFF
--- a/src/ansys/dpf/core/any.py
+++ b/src/ansys/dpf/core/any.py
@@ -348,4 +348,8 @@ class Any:
                 if obj is not None:
                     self._deleter_func[0](obj)
         except Exception:
-            warnings.warn(traceback.format_exc())
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())

--- a/src/ansys/dpf/core/collection_base.py
+++ b/src/ansys/dpf/core/collection_base.py
@@ -578,8 +578,12 @@ class CollectionBase(Generic[TYPE]):
                 obj = self._deleter_func[1](self)
                 if obj is not None:
                     self._deleter_func[0](obj)
-        except:
-            warnings.warn(traceback.format_exc())
+        except Exception:
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())
 
     def _get_ownership(self):
         self.owned = True

--- a/src/ansys/dpf/core/config.py
+++ b/src/ansys/dpf/core/config.py
@@ -311,6 +311,13 @@ class Config:
     def __del__(self):
         """Delete this instance of config."""
         try:
-            self._deleter_func[0](self._deleter_func[1](self))
-        except:
-            warnings.warn(traceback.format_exc())
+            if hasattr(self, "_deleter_func"):
+                obj = self._deleter_func[1](self)
+                if obj is not None:
+                    self._deleter_func[0](obj)
+        except Exception:
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())

--- a/src/ansys/dpf/core/cyclic_support.py
+++ b/src/ansys/dpf/core/cyclic_support.py
@@ -363,6 +363,13 @@ class CyclicSupport:
     def __del__(self):
         """Delete this instance."""
         try:
-            self._deleter_func[0](self._deleter_func[1](self))
-        except:
-            warnings.warn(traceback.format_exc())
+            if hasattr(self, "_deleter_func"):
+                obj = self._deleter_func[1](self)
+                if obj is not None:
+                    self._deleter_func[0](obj)
+        except Exception:
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())

--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -782,9 +782,7 @@ class DataSources:
                 if obj is not None:
                     self._deleter_func[0](obj)
         except Exception:
-            # During interpreter shutdown the ``warnings`` and ``traceback``
-            # module globals (or their functions) may already be torn down;
-            # resolve them safely to avoid a secondary error in __del__.
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)
             format_exc = getattr(traceback, "format_exc", None)
             if warn is not None and format_exc is not None:

--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -777,7 +777,15 @@ class DataSources:
     def __del__(self):
         """Delete this instance."""
         try:
-            self._deleter_func[0](self._deleter_func[1](self))
-        except:
-            warnings.warn(traceback.format_exc())
-            pass
+            if hasattr(self, "_deleter_func"):
+                obj = self._deleter_func[1](self)
+                if obj is not None:
+                    self._deleter_func[0](obj)
+        except Exception:
+            # During interpreter shutdown the ``warnings`` and ``traceback``
+            # module globals (or their functions) may already be torn down;
+            # resolve them safely to avoid a secondary error in __del__.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())

--- a/src/ansys/dpf/core/data_tree.py
+++ b/src/ansys/dpf/core/data_tree.py
@@ -640,8 +640,12 @@ class DataTree:
                 obj = self._deleter_func[1](self)
                 if obj is not None:
                     self._deleter_func[0](obj)
-        except:
-            warnings.warn(traceback.format_exc())
+        except Exception:
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())
 
 
 class _LocalDataTree(DataTree):

--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -798,8 +798,12 @@ class Operator:
                 obj = self._deleter_func[1](self)
                 if obj is not None:
                     self._deleter_func[0](obj)
-        except:
-            warnings.warn(traceback.format_exc())
+        except Exception:
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())
 
     def __str__(self):
         """Describe the entity.

--- a/src/ansys/dpf/core/field_base.py
+++ b/src/ansys/dpf/core/field_base.py
@@ -246,8 +246,12 @@ class _FieldBase:
         try:
             if hasattr(self, "_deleter_func"):
                 self._deleter_func[0](self._deleter_func[1](self))
-        except:
-            warnings.warn(traceback.format_exc())
+        except Exception:
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())
 
     @abstractmethod
     def _set_scoping(self, scoping):

--- a/src/ansys/dpf/core/field_definition.py
+++ b/src/ansys/dpf/core/field_definition.py
@@ -313,6 +313,13 @@ class FieldDefinition:
     def __del__(self):
         """Delete the current instance."""
         try:
-            self._deleter_func[0](self._deleter_func[1](self))
-        except:
-            warnings.warn(traceback.format_exc())
+            if hasattr(self, "_deleter_func"):
+                obj = self._deleter_func[1](self)
+                if obj is not None:
+                    self._deleter_func[0](obj)
+        except Exception:
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())

--- a/src/ansys/dpf/core/generic_data_container.py
+++ b/src/ansys/dpf/core/generic_data_container.py
@@ -209,6 +209,9 @@ class GenericDataContainer:
         if self._internal_obj is not None:
             try:
                 self._deleter_func[0](self._deleter_func[1](self))
-            except Exception as e:
-                print(str(e.args), str(self._deleter_func[0]))
-                warnings.warn(traceback.format_exc())
+            except Exception:
+                # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+                warn = getattr(warnings, "warn", None)
+                format_exc = getattr(traceback, "format_exc", None)
+                if warn is not None and format_exc is not None:
+                    warn(format_exc())

--- a/src/ansys/dpf/core/label_space.py
+++ b/src/ansys/dpf/core/label_space.py
@@ -223,6 +223,13 @@ class LabelSpace:
         None
         """
         try:
-            self._deleter_func[0](self._deleter_func[1](self))
-        except:
-            warnings.warn(traceback.format_exc())
+            if hasattr(self, "_deleter_func"):
+                obj = self._deleter_func[1](self)
+                if obj is not None:
+                    self._deleter_func[0](obj)
+        except Exception:
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())

--- a/src/ansys/dpf/core/meshed_region.py
+++ b/src/ansys/dpf/core/meshed_region.py
@@ -346,9 +346,16 @@ class MeshedRegion:
     def __del__(self):
         """Delete this instance of the meshed region."""
         try:
-            self._deleter_func[0](self._deleter_func[1](self))
-        except:
-            warnings.warn(traceback.format_exc())
+            if hasattr(self, "_deleter_func"):
+                obj = self._deleter_func[1](self)
+                if obj is not None:
+                    self._deleter_func[0](obj)
+        except Exception:
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())
 
     def __str__(self):
         """Return string representation of the meshed region."""

--- a/src/ansys/dpf/core/result_info.py
+++ b/src/ansys/dpf/core/result_info.py
@@ -632,6 +632,13 @@ class ResultInfo:
             If an exception occurs while attempting to delete resources.
         """
         try:
-            self._deleter_func[0](self._deleter_func[1](self))
-        except:
-            warnings.warn(traceback.format_exc())
+            if hasattr(self, "_deleter_func"):
+                obj = self._deleter_func[1](self)
+                if obj is not None:
+                    self._deleter_func[0](obj)
+        except Exception:
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())

--- a/src/ansys/dpf/core/scoping.py
+++ b/src/ansys/dpf/core/scoping.py
@@ -396,10 +396,16 @@ class Scoping:
             If an exception occurs while attempting to delete resources.
         """
         try:
-            self._deleter_func[0](self._deleter_func[1](self))
-        except Exception as e:
-            print(str(e.args), str(self._deleter_func[0]))
-            warnings.warn(traceback.format_exc())
+            if hasattr(self, "_deleter_func"):
+                obj = self._deleter_func[1](self)
+                if obj is not None:
+                    self._deleter_func[0](obj)
+        except Exception:
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())
 
     def __iter__(self):
         """Return an iterator over the scoping ids."""

--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -806,9 +806,16 @@ class GrpcClient:
             If an exception occurs while attempting to delete resources.
         """
         try:
-            self._deleter_func[0](self._deleter_func[1](self))
-        except:
-            warnings.warn(traceback.format_exc())
+            if hasattr(self, "_deleter_func"):
+                obj = self._deleter_func[1](self)
+                if obj is not None:
+                    self._deleter_func[0](obj)
+        except Exception:
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())
 
 
 class GrpcServer(CServer):

--- a/src/ansys/dpf/core/streams_container.py
+++ b/src/ansys/dpf/core/streams_container.py
@@ -208,8 +208,12 @@ class StreamsContainer:
             # delete
             if not getattr(self, "owned", False):
                 self._deleter_func[0](self._deleter_func[1](self))
-        except:  # pylint: disable=bare-except
-            warnings.warn(traceback.format_exc())
+        except Exception:
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())
 
     def add_stream(
         self, stream: Stream, group: int = None, is_result: int = None, result: int = None

--- a/src/ansys/dpf/core/support.py
+++ b/src/ansys/dpf/core/support.py
@@ -358,6 +358,13 @@ class Support:
             If an exception occurs while attempting to delete resources.
         """
         try:
-            self._deleter_func[0](self._deleter_func[1](self))
-        except:
-            warnings.warn(traceback.format_exc())
+            if hasattr(self, "_deleter_func"):
+                obj = self._deleter_func[1](self)
+                if obj is not None:
+                    self._deleter_func[0](obj)
+        except Exception:
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())

--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -1018,8 +1018,12 @@ class Workflow:
             if hasattr(self, "_internal_obj"):
                 if self._internal_obj is not None and self._internal_obj != "None":
                     self._deleter_func[0](self._deleter_func[1](self))
-        except:
-            warnings.warn(traceback.format_exc())
+        except Exception:
+            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
+            warn = getattr(warnings, "warn", None)
+            format_exc = getattr(traceback, "format_exc", None)
+            if warn is not None and format_exc is not None:
+                warn(format_exc())
 
     def __str__(self):
         """Describe the entity.


### PR DESCRIPTION
This pull request improves the robustness and safety of resource cleanup in destructor (`__del__`) methods across multiple classes in the codebase. The main focus is to ensure that warnings about exceptions during object deletion are only issued when the `warnings` and `traceback` modules are available—particularly important during Python interpreter shutdown. Additionally, the destructors now more safely check for the existence of deleter functions and handle object deletion more gracefully.

Key improvements include:

**Robust Exception Handling in Destructors:**

* All `__del__` methods now check for the existence of the `warnings.warn` and `traceback.format_exc` functions before attempting to issue a warning, preventing potential errors during interpreter shutdown. [[1]](diffhunk://#diff-b9e9a362f077ad1820aa5c8d7b9d33739eb7c1051a2a62d4465822ecc3b9ecbcL351-R355) [[2]](diffhunk://#diff-8430aefa8464de2160e6ef55f194c4531794f773bbe9d09a410ed95d03495f70L581-R586) [[3]](diffhunk://#diff-c9a593f53af9e46e660404ce201993da4b4636d6a47a7bdcae31b29de4851519L314-R323) [[4]](diffhunk://#diff-f554a66f2d6d8e76ee70e7ad752ea45147d838e455393dd8f7129f0d9cc78cafL366-R375) [[5]](diffhunk://#diff-c1427122b795232bc959f7ddb5001bea9b01e2e0de86fa0ebb08a89df4e5f520L780-R789) [[6]](diffhunk://#diff-73b4514f2305b501c578f8923759dc31a9ae0b6ca286cd2894e7b957e02c4606L643-R648) [[7]](diffhunk://#diff-4db5635bff5ab0208ed7e2b83876b304fbb5817cec4aed81e0a23dc21fa5df6bL801-R806) [[8]](diffhunk://#diff-36c9a29f2862d45c39897224c1d7b5063bce534de70838d9b5c9eb74af3d10f3L249-R254) [[9]](diffhunk://#diff-3fa34ae6d6e78bff821f38e15647e22adedb2a41c687b1a24388bf5dde98be47L316-R325) [[10]](diffhunk://#diff-d3774f451995103812203c97e2f5f6453b6a33226c708a79be646c6bce8af7b1L212-R217) [[11]](diffhunk://#diff-de5341538912b9658a1c9a5b5fdec8cf210c582ab95e4301e82a9834bb25a4b2L226-R235) [[12]](diffhunk://#diff-285c0d72cf4a64785df5e97acf11751958e04a68e182e478b7076a1f1530374eL349-R358) [[13]](diffhunk://#diff-d50b57e82c2ed0ee58910d5333b6f4852f4eb649adc88456216f0871d4645704L635-R644) [[14]](diffhunk://#diff-6b30fb80f0c90b6a1ec9998f00aefe5196ba326c5ee4738919bc85bec45dc608L399-R408) [[15]](diffhunk://#diff-b3b8f0d3982c52b95c954d8d4f33fc3fe51aa11ebafaaf4a7be7db134a41fad5L809-R818) [[16]](diffhunk://#diff-8df0c18ce70838ecf163d146b92263efb0a486c185f169ddd85ab1d0533498adL211-R216) [[17]](diffhunk://#diff-e700af6fc42b0f155420dcf434cce7bcd065ac7f674331e9d0d610a58dd325c3L361-R370) [[18]](diffhunk://#diff-279a881f9d7bba519ae8c097965ef68d08a29746639a5cc9b9ab6b4b4e0150ecL1021-R1026)

**Safer Deletion Logic:**

* Many destructors now verify the presence of the `_deleter_func` attribute and ensure the object to be deleted is not `None` before invoking deleter functions, reducing the risk of errors if the object is partially initialized or already cleaned up. [[1]](diffhunk://#diff-c9a593f53af9e46e660404ce201993da4b4636d6a47a7bdcae31b29de4851519L314-R323) [[2]](diffhunk://#diff-f554a66f2d6d8e76ee70e7ad752ea45147d838e455393dd8f7129f0d9cc78cafL366-R375) [[3]](diffhunk://#diff-c1427122b795232bc959f7ddb5001bea9b01e2e0de86fa0ebb08a89df4e5f520L780-R789) [[4]](diffhunk://#diff-de5341538912b9658a1c9a5b5fdec8cf210c582ab95e4301e82a9834bb25a4b2L226-R235) [[5]](diffhunk://#diff-285c0d72cf4a64785df5e97acf11751958e04a68e182e478b7076a1f1530374eL349-R358) [[6]](diffhunk://#diff-d50b57e82c2ed0ee58910d5333b6f4852f4eb649adc88456216f0871d4645704L635-R644) [[7]](diffhunk://#diff-6b30fb80f0c90b6a1ec9998f00aefe5196ba326c5ee4738919bc85bec45dc608L399-R408) [[8]](diffhunk://#diff-b3b8f0d3982c52b95c954d8d4f33fc3fe51aa11ebafaaf4a7be7db134a41fad5L809-R818) [[9]](diffhunk://#diff-e700af6fc42b0f155420dcf434cce7bcd065ac7f674331e9d0d610a58dd325c3L361-R370)

These changes make the codebase more resilient to edge cases during object finalization and interpreter shutdown, improving maintainability and reliability.