### PR TITLE
ci: bump default Python to 3.12 for docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
       python_version:
         required: false
         type: string
-        default: "3.11"
+        default: "3.12"
       ANSYS_VERSION:
         required: false
         type: string
@@ -33,7 +33,7 @@ on:
         description: "Python interpreter"
         required: true
         type: string
-        default: "3.11"
+        default: "3.12"
       ANSYS_VERSION:
         description: "ANSYS version"
         required: false


### PR DESCRIPTION
Due to the latest bump in `ansys-sphinx-theme`, Python 3.12 is now required to generate the documentation with its latest version.