### PR TITLE
refactor: style check magic number error for custom xml context type

### DIFF
--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -151,7 +151,10 @@ def _run_launch_server_process(  # noqa: PLR0913
             AvailableServerContexts.entry,
             AvailableServerContexts.premium,
         ):
-            if context.licensing_context_type == CUSTOM_XML_CONTEXT_TYPE and len(context.xml_path) > 0:  # 2 == custom xml
+            if (
+                context.licensing_context_type == CUSTOM_XML_CONTEXT_TYPE
+                and len(context.xml_path) > 0
+            ):  # 2 == custom xml
                 run_cmd.append(f"--context {context.xml_path}")
             else:
                 run_cmd.append(f"--context {int(context.licensing_context_type)}")

--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -70,6 +70,8 @@ RUNNING_DOCKER = server_factory.create_default_docker_config()
 
 MAX_PORT = 65535
 
+CUSTOM_XML_CONTEXT_TYPE = 2
+
 
 def _get_dll_path(name, ansys_path=None):
     """Helper-function to get the right dll path for Linux or Windows."""
@@ -149,7 +151,7 @@ def _run_launch_server_process(  # noqa: PLR0913
             AvailableServerContexts.entry,
             AvailableServerContexts.premium,
         ):
-            if context.licensing_context_type == 2 and len(context.xml_path) > 0:  # 2 == custom xml
+            if context.licensing_context_type == CUSTOM_XML_CONTEXT_TYPE and len(context.xml_path) > 0:  # 2 == custom xml
                 run_cmd.append(f"--context {context.xml_path}")
             else:
                 run_cmd.append(f"--context {int(context.licensing_context_type)}")


### PR DESCRIPTION
This pull request introduces a small improvement to the handling of server context types in the `src/ansys/dpf/core/server_types.py` file. The main change is the introduction of a named constant to improve code readability and maintainability.

Improvements to code clarity:

* Defined a new constant `CUSTOM_XML_CONTEXT_TYPE` to replace the hardcoded value `2` when checking for custom XML licensing context types.
* Updated the condition in `_run_launch_server_process` to use the new `CUSTOM_XML_CONTEXT_TYPE` constant instead of the literal `2`.