### PR TITLE
fix: centralize safe DPF cleanup across API loading and shutdown

### DIFF
--- a/src/ansys/dpf/core/_cleanup.py
+++ b/src/ansys/dpf/core/_cleanup.py
@@ -27,6 +27,11 @@ import warnings
 from ansys.dpf.gate.generated import capi as _gate_capi
 
 
+def _is_local_capi_deleter(deleter):
+    """Return whether a deleter calls the generated in-process C API."""
+    return getattr(deleter, "__module__", "").startswith("ansys.dpf.gate.generated.")
+
+
 def release_dpf_object(obj):
     """Release a DPF object through its configured native deleter."""
     if sys is None or sys.is_finalizing():
@@ -37,7 +42,12 @@ def release_dpf_object(obj):
             return
         native_obj = deleter[1](obj)
         if native_obj is not None:
-            _gate_capi._call_or_defer(deleter[0], native_obj)
+            if getattr(_gate_capi, "_api_loading", False) and not _is_local_capi_deleter(
+                deleter[0]
+            ):
+                deleter[0](native_obj)
+            else:
+                _gate_capi._call_or_defer(deleter[0], native_obj)
     except Exception:
         warn = getattr(warnings, "warn", None)
         format_exc = getattr(traceback, "format_exc", None)

--- a/src/ansys/dpf/core/_cleanup.py
+++ b/src/ansys/dpf/core/_cleanup.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2020 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import sys
+import traceback
+import warnings
+
+from ansys.dpf.gate.generated import capi as _gate_capi
+
+
+def release_dpf_object(obj):
+    """Release a DPF object through its configured native deleter."""
+    if sys is None or sys.is_finalizing():
+        return
+    try:
+        deleter = getattr(obj, "_deleter_func", None)
+        if deleter is None:
+            return
+        native_obj = deleter[1](obj)
+        if native_obj is not None:
+            _gate_capi._call_or_defer(deleter[0], native_obj)
+    except Exception:
+        warn = getattr(warnings, "warn", None)
+        format_exc = getattr(traceback, "format_exc", None)
+        if warn is not None and format_exc is not None:
+            warn(format_exc())

--- a/src/ansys/dpf/core/any.py
+++ b/src/ansys/dpf/core/any.py
@@ -343,13 +343,11 @@ class Any:
 
     def __del__(self):
         """Delete the entry."""
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)
                 if obj is not None:
-                    self._deleter_func[0](obj)
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/any.py
+++ b/src/ansys/dpf/core/any.py
@@ -36,6 +36,7 @@ from ansys.dpf.core.check_version import server_meet_version, server_meet_versio
 from ansys.dpf.core.common import create_dpf_instance
 import ansys.dpf.core.server_types
 from ansys.dpf.gate import any_abstract_api, dpf_vector, integral_types
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class Any:
@@ -342,6 +343,8 @@ class Any:
 
     def __del__(self):
         """Delete the entry."""
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)

--- a/src/ansys/dpf/core/any.py
+++ b/src/ansys/dpf/core/any.py
@@ -26,17 +26,14 @@ Any.
 Module containing the wrapper class representing all supported DPF datatypes.
 """
 
-import traceback
-import warnings
-
 import numpy as np
 
 from ansys.dpf.core import errors, server as server_module
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.check_version import server_meet_version, server_meet_version_and_raise
 from ansys.dpf.core.common import create_dpf_instance
 import ansys.dpf.core.server_types
 from ansys.dpf.gate import any_abstract_api, dpf_vector, integral_types
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class Any:
@@ -343,14 +340,4 @@ class Any:
 
     def __del__(self):
         """Delete the entry."""
-        try:
-            if hasattr(self, "_deleter_func"):
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        release_dpf_object(self)

--- a/src/ansys/dpf/core/collection_base.py
+++ b/src/ansys/dpf/core/collection_base.py
@@ -25,13 +25,12 @@
 from __future__ import annotations
 
 import abc
-import traceback
 from typing import TYPE_CHECKING, Generic, List, Optional, TypeVar
-import warnings
 
 import numpy as np
 
 from ansys.dpf.core import server as server_module
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.check_version import version_requires
 from ansys.dpf.core.label_space import LabelSpace
 from ansys.dpf.core.scoping import Scoping
@@ -44,7 +43,6 @@ from ansys.dpf.gate import (
     dpf_array,
     dpf_vector,
 )
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 if TYPE_CHECKING:  # pragma: no cover
     from ansys.dpf.core.support import Support
@@ -573,18 +571,8 @@ class CollectionBase(Generic[TYPE]):
 
     def __del__(self):
         """Delete the entry."""
-        try:
-            # delete
-            if not self.owned:
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        if not getattr(self, "owned", False):
+            release_dpf_object(self)
 
     def _get_ownership(self):
         self.owned = True

--- a/src/ansys/dpf/core/collection_base.py
+++ b/src/ansys/dpf/core/collection_base.py
@@ -44,6 +44,7 @@ from ansys.dpf.gate import (
     dpf_array,
     dpf_vector,
 )
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 if TYPE_CHECKING:  # pragma: no cover
     from ansys.dpf.core.support import Support
@@ -572,6 +573,8 @@ class CollectionBase(Generic[TYPE]):
 
     def __del__(self):
         """Delete the entry."""
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             # delete
             if not self.owned:

--- a/src/ansys/dpf/core/collection_base.py
+++ b/src/ansys/dpf/core/collection_base.py
@@ -573,14 +573,12 @@ class CollectionBase(Generic[TYPE]):
 
     def __del__(self):
         """Delete the entry."""
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         try:
             # delete
             if not self.owned:
                 obj = self._deleter_func[1](self)
                 if obj is not None:
-                    self._deleter_func[0](obj)
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/config.py
+++ b/src/ansys/dpf/core/config.py
@@ -33,6 +33,7 @@ from ansys.dpf.gate import (
     operator_config_capi,
     operator_config_grpcapi,
 )
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class Config:
@@ -310,6 +311,8 @@ class Config:
 
     def __del__(self):
         """Delete this instance of config."""
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)

--- a/src/ansys/dpf/core/config.py
+++ b/src/ansys/dpf/core/config.py
@@ -311,13 +311,11 @@ class Config:
 
     def __del__(self):
         """Delete this instance of config."""
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)
                 if obj is not None:
-                    self._deleter_func[0](obj)
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/config.py
+++ b/src/ansys/dpf/core/config.py
@@ -23,17 +23,15 @@
 """Operator Configuration."""
 
 import functools
-import traceback
-import warnings
 
 from ansys.dpf.core import server as server_module
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.operator_specification import Specification
 from ansys.dpf.gate import (
     operator_config_abstract_api,
     operator_config_capi,
     operator_config_grpcapi,
 )
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class Config:
@@ -311,14 +309,4 @@ class Config:
 
     def __del__(self):
         """Delete this instance of config."""
-        try:
-            if hasattr(self, "_deleter_func"):
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        release_dpf_object(self)

--- a/src/ansys/dpf/core/cyclic_support.py
+++ b/src/ansys/dpf/core/cyclic_support.py
@@ -28,6 +28,7 @@ import warnings
 from ansys.dpf.core import field, property_field, server as server_module
 from ansys.dpf.core.scoping import Scoping
 from ansys.dpf.gate import cyclic_support_capi, cyclic_support_grpcapi
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class CyclicSupport:
@@ -362,6 +363,8 @@ class CyclicSupport:
 
     def __del__(self):
         """Delete this instance."""
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)

--- a/src/ansys/dpf/core/cyclic_support.py
+++ b/src/ansys/dpf/core/cyclic_support.py
@@ -363,13 +363,11 @@ class CyclicSupport:
 
     def __del__(self):
         """Delete this instance."""
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)
                 if obj is not None:
-                    self._deleter_func[0](obj)
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/cyclic_support.py
+++ b/src/ansys/dpf/core/cyclic_support.py
@@ -22,13 +22,10 @@
 
 """Cyclic Support."""
 
-import traceback
-import warnings
-
 from ansys.dpf.core import field, property_field, server as server_module
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.scoping import Scoping
 from ansys.dpf.gate import cyclic_support_capi, cyclic_support_grpcapi
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class CyclicSupport:
@@ -363,14 +360,4 @@ class CyclicSupport:
 
     def __del__(self):
         """Delete this instance."""
-        try:
-            if hasattr(self, "_deleter_func"):
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        release_dpf_object(self)

--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -777,13 +777,11 @@ class DataSources:
 
     def __del__(self):
         """Delete this instance."""
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)
                 if obj is not None:
-                    self._deleter_func[0](obj)
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -39,6 +39,7 @@ from ansys.dpf.gate import (
     data_sources_grpcapi,
     integral_types,
 )
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 if TYPE_CHECKING:  # pragma: no cover
     from ansys.dpf import core as dpf
@@ -776,6 +777,8 @@ class DataSources:
 
     def __del__(self):
         """Delete this instance."""
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)

--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -26,11 +26,10 @@ from __future__ import annotations
 
 import os
 from pathlib import Path, PurePosixPath, PureWindowsPath
-import traceback
 from typing import TYPE_CHECKING, Union
-import warnings
 
 from ansys.dpf.core import errors, server as server_module
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.check_version import version_requires
 from ansys.dpf.gate import (
     data_processing_capi,
@@ -39,7 +38,6 @@ from ansys.dpf.gate import (
     data_sources_grpcapi,
     integral_types,
 )
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 if TYPE_CHECKING:  # pragma: no cover
     from ansys.dpf import core as dpf
@@ -777,14 +775,4 @@ class DataSources:
 
     def __del__(self):
         """Delete this instance."""
-        try:
-            if hasattr(self, "_deleter_func"):
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        release_dpf_object(self)

--- a/src/ansys/dpf/core/data_tree.py
+++ b/src/ansys/dpf/core/data_tree.py
@@ -635,14 +635,12 @@ class DataTree:
 
     def __del__(self):
         """Delete this instance."""
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         try:
             # needs a proper deleter only when real datatree and not dict
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)
                 if obj is not None:
-                    self._deleter_func[0](obj)
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/data_tree.py
+++ b/src/ansys/dpf/core/data_tree.py
@@ -23,11 +23,10 @@
 """DataTree."""
 
 import enum
-import traceback
-import warnings
 import weakref
 
 from ansys.dpf.core import collection_base, common, errors, server as server_module
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.common import types
 from ansys.dpf.gate import (
     data_processing_capi,
@@ -37,7 +36,6 @@ from ansys.dpf.gate import (
     dpf_data_tree_grpcapi,
     integral_types,
 )
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class DataTree:
@@ -635,18 +633,7 @@ class DataTree:
 
     def __del__(self):
         """Delete this instance."""
-        try:
-            # needs a proper deleter only when real datatree and not dict
-            if hasattr(self, "_deleter_func"):
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        release_dpf_object(self)
 
 
 class _LocalDataTree(DataTree):

--- a/src/ansys/dpf/core/data_tree.py
+++ b/src/ansys/dpf/core/data_tree.py
@@ -37,6 +37,7 @@ from ansys.dpf.gate import (
     dpf_data_tree_grpcapi,
     integral_types,
 )
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class DataTree:
@@ -634,6 +635,8 @@ class DataTree:
 
     def __del__(self):
         """Delete this instance."""
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             # needs a proper deleter only when real datatree and not dict
             if hasattr(self, "_deleter_func"):

--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 from enum import Enum
 import os
+import sys
 import traceback
 from typing import TYPE_CHECKING
 import warnings
@@ -60,6 +61,7 @@ from ansys.dpf.gate import (
     operator_capi,
     operator_grpcapi,
 )
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 if TYPE_CHECKING:  # pragma: no cover
     from ansys.dpf.core.inputs import _Inputs
@@ -793,6 +795,8 @@ class Operator:
 
     def __del__(self):
         """Delete this instance."""
+        if sys is None or sys.is_finalizing() or getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)

--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -795,13 +795,13 @@ class Operator:
 
     def __del__(self):
         """Delete this instance."""
-        if sys is None or sys.is_finalizing() or getattr(_gate_capi, "_api_loading", False):
+        if sys is None or sys.is_finalizing():
             return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)
                 if obj is not None:
-                    self._deleter_func[0](obj)
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/dpf_operator.py
+++ b/src/ansys/dpf/core/dpf_operator.py
@@ -26,15 +26,13 @@ from __future__ import annotations
 
 from enum import Enum
 import os
-import sys
-import traceback
 from typing import TYPE_CHECKING
-import warnings
 
 import numpy
 from packaging.version import Version
 
 from ansys.dpf.core import server as server_module
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.changelog import Changelog
 from ansys.dpf.core.check_version import (
     server_meet_version,
@@ -61,7 +59,6 @@ from ansys.dpf.gate import (
     operator_capi,
     operator_grpcapi,
 )
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 if TYPE_CHECKING:  # pragma: no cover
     from ansys.dpf.core.inputs import _Inputs
@@ -795,19 +792,7 @@ class Operator:
 
     def __del__(self):
         """Delete this instance."""
-        if sys is None or sys.is_finalizing():
-            return
-        try:
-            if hasattr(self, "_deleter_func"):
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        release_dpf_object(self)
 
     def __str__(self):
         """Describe the entity.

--- a/src/ansys/dpf/core/field_base.py
+++ b/src/ansys/dpf/core/field_base.py
@@ -35,7 +35,7 @@ from ansys.dpf.gate import (
     data_processing_capi,
     data_processing_grpcapi,
 )
-from ansys.dpf.gate.generated import field_abstract_api
+from ansys.dpf.gate.generated import capi as _gate_capi, field_abstract_api
 
 
 class _FieldBase:
@@ -243,6 +243,8 @@ class _FieldBase:
         return self.size
 
     def __del__(self):
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             if hasattr(self, "_deleter_func"):
                 self._deleter_func[0](self._deleter_func[1](self))

--- a/src/ansys/dpf/core/field_base.py
+++ b/src/ansys/dpf/core/field_base.py
@@ -243,11 +243,11 @@ class _FieldBase:
         return self.size
 
     def __del__(self):
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         try:
             if hasattr(self, "_deleter_func"):
-                self._deleter_func[0](self._deleter_func[1](self))
+                obj = self._deleter_func[1](self)
+                if obj is not None:
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/field_base.py
+++ b/src/ansys/dpf/core/field_base.py
@@ -23,19 +23,18 @@
 """Provide base APIs for DPF's field concept and means of caching field data."""
 
 from abc import abstractmethod
-import traceback
-import warnings
 
 import numpy as np
 
 from ansys.dpf.core import errors, scoping, server as server_module
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.cache import _setter
 from ansys.dpf.core.common import locations, natures
 from ansys.dpf.gate import (
     data_processing_capi,
     data_processing_grpcapi,
 )
-from ansys.dpf.gate.generated import capi as _gate_capi, field_abstract_api
+from ansys.dpf.gate.generated import field_abstract_api
 
 
 class _FieldBase:
@@ -243,17 +242,7 @@ class _FieldBase:
         return self.size
 
     def __del__(self):
-        try:
-            if hasattr(self, "_deleter_func"):
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        release_dpf_object(self)
 
     @abstractmethod
     def _set_scoping(self, scoping):

--- a/src/ansys/dpf/core/field_definition.py
+++ b/src/ansys/dpf/core/field_definition.py
@@ -313,13 +313,11 @@ class FieldDefinition:
 
     def __del__(self):
         """Delete the current instance."""
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)
                 if obj is not None:
-                    self._deleter_func[0](obj)
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/field_definition.py
+++ b/src/ansys/dpf/core/field_definition.py
@@ -42,6 +42,7 @@ from ansys.dpf.gate import (
     field_definition_grpcapi,
     integral_types,
 )
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class FieldDefinition:
@@ -312,6 +313,8 @@ class FieldDefinition:
 
     def __del__(self):
         """Delete the current instance."""
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)

--- a/src/ansys/dpf/core/field_definition.py
+++ b/src/ansys/dpf/core/field_definition.py
@@ -24,10 +24,8 @@
 
 from __future__ import annotations
 
-import traceback
-import warnings
-
 from ansys.dpf.core import server as server_module
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.available_result import Homogeneity
 from ansys.dpf.core.check_version import (
     meets_version,
@@ -42,7 +40,6 @@ from ansys.dpf.gate import (
     field_definition_grpcapi,
     integral_types,
 )
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class FieldDefinition:
@@ -313,14 +310,4 @@ class FieldDefinition:
 
     def __del__(self):
         """Delete the current instance."""
-        try:
-            if hasattr(self, "_deleter_func"):
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        release_dpf_object(self)

--- a/src/ansys/dpf/core/generic_data_container.py
+++ b/src/ansys/dpf/core/generic_data_container.py
@@ -41,6 +41,7 @@ from ansys.dpf.core import collection_base, errors, server as server_module, typ
 from ansys.dpf.core.any import Any
 from ansys.dpf.core.dpf_operator import _write_output_type_to_type
 from ansys.dpf.core.mapping_types import map_types_to_python
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class GenericDataContainer:
@@ -206,6 +207,8 @@ class GenericDataContainer:
 
     def __del__(self):
         """Delete the current instance."""
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         if self._internal_obj is not None:
             try:
                 self._deleter_func[0](self._deleter_func[1](self))

--- a/src/ansys/dpf/core/generic_data_container.py
+++ b/src/ansys/dpf/core/generic_data_container.py
@@ -25,9 +25,7 @@
 from __future__ import annotations
 
 import builtins
-import traceback
 from typing import TYPE_CHECKING, Union
-import warnings
 
 import numpy as np
 
@@ -38,10 +36,10 @@ if TYPE_CHECKING:  # pragma: no cover
     from ansys.dpf.core import Field, GenericDataContainer, Scoping, StringField
 
 from ansys.dpf.core import collection_base, errors, server as server_module, types
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.any import Any
 from ansys.dpf.core.dpf_operator import _write_output_type_to_type
 from ansys.dpf.core.mapping_types import map_types_to_python
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class GenericDataContainer:
@@ -207,14 +205,5 @@ class GenericDataContainer:
 
     def __del__(self):
         """Delete the current instance."""
-        if self._internal_obj is not None:
-            try:
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-            except Exception:
-                # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-                warn = getattr(warnings, "warn", None)
-                format_exc = getattr(traceback, "format_exc", None)
-                if warn is not None and format_exc is not None:
-                    warn(format_exc())
+        if getattr(self, "_internal_obj", None) is not None:
+            release_dpf_object(self)

--- a/src/ansys/dpf/core/generic_data_container.py
+++ b/src/ansys/dpf/core/generic_data_container.py
@@ -207,11 +207,11 @@ class GenericDataContainer:
 
     def __del__(self):
         """Delete the current instance."""
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         if self._internal_obj is not None:
             try:
-                self._deleter_func[0](self._deleter_func[1](self))
+                obj = self._deleter_func[1](self)
+                if obj is not None:
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
             except Exception:
                 # During interpreter shutdown, ``warnings``/``traceback`` may be None.
                 warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/label_space.py
+++ b/src/ansys/dpf/core/label_space.py
@@ -223,13 +223,11 @@ class LabelSpace:
         -------
         None
         """
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)
                 if obj is not None:
-                    self._deleter_func[0](obj)
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/label_space.py
+++ b/src/ansys/dpf/core/label_space.py
@@ -55,6 +55,7 @@ from ansys.dpf.gate import (
     label_space_capi,
     label_space_grpcapi,
 )
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class LabelSpace:
@@ -222,6 +223,8 @@ class LabelSpace:
         -------
         None
         """
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)

--- a/src/ansys/dpf/core/label_space.py
+++ b/src/ansys/dpf/core/label_space.py
@@ -39,9 +39,7 @@ LabelSpace enables advanced data organization and querying in DPF workflows.
 
 from __future__ import annotations
 
-import traceback
 from typing import TYPE_CHECKING
-import warnings
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Generator
@@ -49,13 +47,13 @@ if TYPE_CHECKING:  # pragma: no cover
     from ansys.dpf.core.server import AnyServerType
 
 from ansys.dpf.core import server as server_module
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.gate import (
     data_processing_capi,
     data_processing_grpcapi,
     label_space_capi,
     label_space_grpcapi,
 )
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class LabelSpace:
@@ -223,14 +221,4 @@ class LabelSpace:
         -------
         None
         """
-        try:
-            if hasattr(self, "_deleter_func"):
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        release_dpf_object(self)

--- a/src/ansys/dpf/core/meshed_region.py
+++ b/src/ansys/dpf/core/meshed_region.py
@@ -52,6 +52,7 @@ from ansys.dpf.core.faces import Faces
 from ansys.dpf.core.nodes import Nodes
 from ansys.dpf.core.plotter import DpfPlotter
 from ansys.dpf.gate import meshed_region_capi, meshed_region_grpcapi
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 def update_grid(func):
@@ -348,6 +349,8 @@ class MeshedRegion:
 
     def __del__(self):
         """Delete this instance of the meshed region."""
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)

--- a/src/ansys/dpf/core/meshed_region.py
+++ b/src/ansys/dpf/core/meshed_region.py
@@ -349,13 +349,11 @@ class MeshedRegion:
 
     def __del__(self):
         """Delete this instance of the meshed region."""
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)
                 if obj is not None:
-                    self._deleter_func[0](obj)
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/meshed_region.py
+++ b/src/ansys/dpf/core/meshed_region.py
@@ -33,12 +33,11 @@ if TYPE_CHECKING:  # pragma: nocover
     from ansys.dpf.core.scoping import Scoping
     from ansys.dpf.core.server_types import AnyServerType
 
-import traceback
-import warnings
 
 import numpy as np
 
 from ansys.dpf.core import field, property_field, scoping, server as server_module
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.cache import class_handling_cache
 from ansys.dpf.core.check_version import meets_version, version_requires
 from ansys.dpf.core.common import (
@@ -52,7 +51,6 @@ from ansys.dpf.core.faces import Faces
 from ansys.dpf.core.nodes import Nodes
 from ansys.dpf.core.plotter import DpfPlotter
 from ansys.dpf.gate import meshed_region_capi, meshed_region_grpcapi
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 def update_grid(func):
@@ -349,17 +347,7 @@ class MeshedRegion:
 
     def __del__(self):
         """Delete this instance of the meshed region."""
-        try:
-            if hasattr(self, "_deleter_func"):
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        release_dpf_object(self)
 
     def __str__(self):
         """Return string representation of the meshed region."""

--- a/src/ansys/dpf/core/result_info.py
+++ b/src/ansys/dpf/core/result_info.py
@@ -45,6 +45,7 @@ from ansys.dpf.gate import (
     result_info_capi,
     result_info_grpcapi,
 )
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 @unique
@@ -631,6 +632,8 @@ class ResultInfo:
         Warning
             If an exception occurs while attempting to delete resources.
         """
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)

--- a/src/ansys/dpf/core/result_info.py
+++ b/src/ansys/dpf/core/result_info.py
@@ -632,13 +632,11 @@ class ResultInfo:
         Warning
             If an exception occurs while attempting to delete resources.
         """
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)
                 if obj is not None:
-                    self._deleter_func[0](obj)
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/result_info.py
+++ b/src/ansys/dpf/core/result_info.py
@@ -23,12 +23,11 @@
 """ResultInfo."""
 
 from enum import Enum, unique
-import traceback
 from types import SimpleNamespace
 from typing import List, Union
-import warnings
 
 from ansys.dpf.core import available_result, collection_base, server as server_module, support
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.available_result import Homogeneity
 from ansys.dpf.core.check_version import version_requires
 from ansys.dpf.core.common import locations
@@ -45,7 +44,6 @@ from ansys.dpf.gate import (
     result_info_capi,
     result_info_grpcapi,
 )
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 @unique
@@ -632,14 +630,4 @@ class ResultInfo:
         Warning
             If an exception occurs while attempting to delete resources.
         """
-        try:
-            if hasattr(self, "_deleter_func"):
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        release_dpf_object(self)

--- a/src/ansys/dpf/core/scoping.py
+++ b/src/ansys/dpf/core/scoping.py
@@ -44,6 +44,7 @@ from ansys.dpf.gate import (
     utils,
 )
 from ansys.dpf.gate.dpf_array import DPFArray
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 if TYPE_CHECKING:  # pragma: nocover
     from ctypes import c_void_p as ScopingPointer
@@ -395,6 +396,8 @@ class Scoping:
         Warning
             If an exception occurs while attempting to delete resources.
         """
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)

--- a/src/ansys/dpf/core/scoping.py
+++ b/src/ansys/dpf/core/scoping.py
@@ -25,13 +25,12 @@
 from __future__ import annotations
 
 import ctypes
-import traceback
 from typing import TYPE_CHECKING, Union
-import warnings
 
 import numpy as np
 
 from ansys.dpf.core import server as server_module, server_types
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.cache import _setter
 from ansys.dpf.core.check_version import version_requires
 from ansys.dpf.core.common import locations
@@ -44,7 +43,6 @@ from ansys.dpf.gate import (
     utils,
 )
 from ansys.dpf.gate.dpf_array import DPFArray
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 if TYPE_CHECKING:  # pragma: nocover
     from ctypes import c_void_p as ScopingPointer
@@ -396,17 +394,7 @@ class Scoping:
         Warning
             If an exception occurs while attempting to delete resources.
         """
-        try:
-            if hasattr(self, "_deleter_func"):
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        release_dpf_object(self)
 
     def __iter__(self):
         """Return an iterator over the scoping ids."""

--- a/src/ansys/dpf/core/scoping.py
+++ b/src/ansys/dpf/core/scoping.py
@@ -396,13 +396,11 @@ class Scoping:
         Warning
             If an exception occurs while attempting to delete resources.
         """
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)
                 if obj is not None:
-                    self._deleter_func[0](obj)
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -772,6 +772,8 @@ class CServer(BaseServer, ABC):
         Warning
             If an exception occurs while attempting to delete resources.
         """
+        if sys is None or sys.is_finalizing():
+            return
         try:
             self._del_session()
             if self._own_process:
@@ -814,13 +816,11 @@ class GrpcClient:
         Warning
             If an exception occurs while attempting to delete resources.
         """
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)
                 if obj is not None:
-                    self._deleter_func[0](obj)
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)
@@ -1681,6 +1681,8 @@ class LegacyGrpcServer(BaseServer):
         Warning
             If an exception occurs while attempting to delete resources.
         """
+        if sys is None or sys.is_finalizing():
+            return
         try:
             self._del_session()
             if self._own_process:

--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -49,6 +49,7 @@ import psutil
 
 from ansys.dpf import core
 from ansys.dpf.core import __version__, errors, server_context, server_factory
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core._version import (
     CALENDAR_VERSIONING_FIRST_MAJOR,
     min_server_version,
@@ -57,7 +58,6 @@ from ansys.dpf.core._version import (
 from ansys.dpf.core.check_version import get_server_version, meets_version, version_requires
 from ansys.dpf.core.server_context import AvailableServerContexts, ServerContext
 from ansys.dpf.gate import data_processing_grpcapi, load_api
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 if TYPE_CHECKING:  # pragma: no cover
     from ansys.dpf.core.server_factory import DockerConfig
@@ -816,17 +816,7 @@ class GrpcClient:
         Warning
             If an exception occurs while attempting to delete resources.
         """
-        try:
-            if hasattr(self, "_deleter_func"):
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        release_dpf_object(self)
 
 
 class GrpcServer(CServer):

--- a/src/ansys/dpf/core/server_types.py
+++ b/src/ansys/dpf/core/server_types.py
@@ -57,6 +57,7 @@ from ansys.dpf.core._version import (
 from ansys.dpf.core.check_version import get_server_version, meets_version, version_requires
 from ansys.dpf.core.server_context import AvailableServerContexts, ServerContext
 from ansys.dpf.gate import data_processing_grpcapi, load_api
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 if TYPE_CHECKING:  # pragma: no cover
     from ansys.dpf.core.server_factory import DockerConfig
@@ -813,6 +814,8 @@ class GrpcClient:
         Warning
             If an exception occurs while attempting to delete resources.
         """
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)

--- a/src/ansys/dpf/core/session.py
+++ b/src/ansys/dpf/core/session.py
@@ -37,6 +37,7 @@ from ansys.dpf.core.common import (
     _progress_bar_is_available,
 )
 from ansys.dpf.gate import capi, session_capi, session_grpcapi
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 LOG = logging.getLogger(__name__)
 
@@ -341,7 +342,9 @@ class Session:
         """
         try:
             if not self._released:
-                self._deleter_func[0](self._deleter_func[1](self))
+                obj = self._deleter_func[1](self)
+                if obj is not None:
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except:
             warnings.warn(traceback.format_exc())
         self._released = True

--- a/src/ansys/dpf/core/session.py
+++ b/src/ansys/dpf/core/session.py
@@ -26,18 +26,16 @@ import abc
 import ctypes
 import logging
 import threading
-import traceback
-import warnings
 import weakref
 
 from ansys.dpf.core import data_tree, errors, server as server_module, server_types
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.check_version import version_requires
 from ansys.dpf.core.common import (
     _common_percentage_progress_bar,
     _progress_bar_is_available,
 )
 from ansys.dpf.gate import capi, session_capi, session_grpcapi
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 LOG = logging.getLogger(__name__)
 
@@ -340,14 +338,9 @@ class Session:
         Warning
             If an exception occurs while attempting to delete resources.
         """
-        try:
-            if not self._released:
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except:
-            warnings.warn(traceback.format_exc())
-        self._released = True
+        if not getattr(self, "_released", False):
+            release_dpf_object(self)
+            self._released = True
 
     def __del__(self):
         """Clean up resources associated with the instance."""

--- a/src/ansys/dpf/core/streams_container.py
+++ b/src/ansys/dpf/core/streams_container.py
@@ -205,12 +205,12 @@ class StreamsContainer:
 
     def __del__(self):
         """Delete the entry."""
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         try:
             # delete
             if not getattr(self, "owned", False):
-                self._deleter_func[0](self._deleter_func[1](self))
+                obj = self._deleter_func[1](self)
+                if obj is not None:
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/streams_container.py
+++ b/src/ansys/dpf/core/streams_container.py
@@ -40,6 +40,7 @@ from ansys.dpf.gate import (
     integral_types,
     streams_capi,
 )
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class StreamsContainer:
@@ -204,6 +205,8 @@ class StreamsContainer:
 
     def __del__(self):
         """Delete the entry."""
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             # delete
             if not getattr(self, "owned", False):

--- a/src/ansys/dpf/core/streams_container.py
+++ b/src/ansys/dpf/core/streams_container.py
@@ -26,10 +26,8 @@ StreamsContainer.
 Contains classes associated with the DPF StreamsContainer.
 """
 
-import traceback
-import warnings
-
 from ansys.dpf.core import errors, server as server_module
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.data_sources import DataSources
 from ansys.dpf.core.label_space import LabelSpace
 from ansys.dpf.core.server_types import BaseServer
@@ -40,7 +38,6 @@ from ansys.dpf.gate import (
     integral_types,
     streams_capi,
 )
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class StreamsContainer:
@@ -205,18 +202,8 @@ class StreamsContainer:
 
     def __del__(self):
         """Delete the entry."""
-        try:
-            # delete
-            if not getattr(self, "owned", False):
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        if not getattr(self, "owned", False):
+            release_dpf_object(self)
 
     def add_stream(
         self, stream: Stream, group: int = None, is_result: int = None, result: int = None

--- a/src/ansys/dpf/core/support.py
+++ b/src/ansys/dpf/core/support.py
@@ -22,11 +22,10 @@
 
 """Support."""
 
-import traceback
 from typing import TYPE_CHECKING
-import warnings
 
 from ansys.dpf.core import collection_base, server as server_module
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.check_version import version_requires
 from ansys.dpf.core.core import _deep_copy
 from ansys.dpf.gate import (
@@ -36,7 +35,6 @@ from ansys.dpf.gate import (
     support_capi,
     support_grpcapi,
 )
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 if TYPE_CHECKING:
     from ansys.dpf.core import (
@@ -358,14 +356,4 @@ class Support:
         Warning
             If an exception occurs while attempting to delete resources.
         """
-        try:
-            if hasattr(self, "_deleter_func"):
-                obj = self._deleter_func[1](self)
-                if obj is not None:
-                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        release_dpf_object(self)

--- a/src/ansys/dpf/core/support.py
+++ b/src/ansys/dpf/core/support.py
@@ -36,6 +36,7 @@ from ansys.dpf.gate import (
     support_capi,
     support_grpcapi,
 )
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 if TYPE_CHECKING:
     from ansys.dpf.core import (
@@ -357,6 +358,8 @@ class Support:
         Warning
             If an exception occurs while attempting to delete resources.
         """
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)

--- a/src/ansys/dpf/core/support.py
+++ b/src/ansys/dpf/core/support.py
@@ -358,13 +358,11 @@ class Support:
         Warning
             If an exception occurs while attempting to delete resources.
         """
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         try:
             if hasattr(self, "_deleter_func"):
                 obj = self._deleter_func[1](self)
                 if obj is not None:
-                    self._deleter_func[0](obj)
+                    _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -1015,12 +1015,12 @@ class Workflow:
         Warning
             If an exception occurs while attempting to delete resources.
         """
-        if getattr(_gate_capi, "_api_loading", False):
-            return
         try:
             if hasattr(self, "_internal_obj"):
                 if self._internal_obj is not None and self._internal_obj != "None":
-                    self._deleter_func[0](self._deleter_func[1](self))
+                    obj = self._deleter_func[1](self)
+                    if obj is not None:
+                        _gate_capi._call_or_defer(self._deleter_func[0], obj)
         except Exception:
             # During interpreter shutdown, ``warnings``/``traceback`` may be None.
             warn = getattr(warnings, "warn", None)

--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -51,6 +51,7 @@ from ansys.dpf.gate import (
     workflow_capi,
     workflow_grpcapi,
 )
+from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class Workflow:
@@ -1014,6 +1015,8 @@ class Workflow:
         Warning
             If an exception occurs while attempting to delete resources.
         """
+        if getattr(_gate_capi, "_api_loading", False):
+            return
         try:
             if hasattr(self, "_internal_obj"):
                 if self._internal_obj is not None and self._internal_obj != "None":

--- a/src/ansys/dpf/core/workflow.py
+++ b/src/ansys/dpf/core/workflow.py
@@ -27,14 +27,13 @@ from __future__ import annotations
 from enum import Enum
 import os
 from pathlib import Path
-import traceback
 from typing import Union
-import warnings
 
 import numpy
 
 from ansys import dpf
 from ansys.dpf.core import dpf_operator, inputs, outputs, server as server_module
+from ansys.dpf.core._cleanup import release_dpf_object
 from ansys.dpf.core.check_version import (
     server_meet_version,
     server_meet_version_and_raise,
@@ -51,7 +50,6 @@ from ansys.dpf.gate import (
     workflow_capi,
     workflow_grpcapi,
 )
-from ansys.dpf.gate.generated import capi as _gate_capi
 
 
 class Workflow:
@@ -1015,18 +1013,9 @@ class Workflow:
         Warning
             If an exception occurs while attempting to delete resources.
         """
-        try:
-            if hasattr(self, "_internal_obj"):
-                if self._internal_obj is not None and self._internal_obj != "None":
-                    obj = self._deleter_func[1](self)
-                    if obj is not None:
-                        _gate_capi._call_or_defer(self._deleter_func[0], obj)
-        except Exception:
-            # During interpreter shutdown, ``warnings``/``traceback`` may be None.
-            warn = getattr(warnings, "warn", None)
-            format_exc = getattr(traceback, "format_exc", None)
-            if warn is not None and format_exc is not None:
-                warn(format_exc())
+        internal_obj = getattr(self, "_internal_obj", None)
+        if internal_obj is not None and internal_obj != "None":
+            release_dpf_object(self)
 
     def __str__(self):
         """Describe the entity.

--- a/src/ansys/dpf/gate/dpf_vector.py
+++ b/src/ansys/dpf/gate/dpf_vector.py
@@ -93,7 +93,7 @@ class DPFVectorBase:
         return self._modified and self.size > 0 # Updating is not necessary for an empty vector. Updating it can cause issue, see #2274
 
     def __del__(self):
-        if sys.is_finalizing() or getattr(_gate_capi, '_api_loading', False):
+        if sys is None or sys.is_finalizing() or getattr(_gate_capi, '_api_loading', False):
             return
         if hasattr(self, "_internal_obj"):
             with suppress(Exception):
@@ -123,7 +123,7 @@ class DPFVectorInt(DPFVectorBase):
         self.dpf_vector_api.dpf_vector_int_commit(self, self.internal_data, self.internal_size, self.has_changed())
 
     def __del__(self):
-        if sys.is_finalizing() or getattr(_gate_capi, '_api_loading', False):
+        if sys is None or sys.is_finalizing() or getattr(_gate_capi, '_api_loading', False):
             return
         with suppress(Exception):
             if hasattr(self, "_array"):
@@ -155,7 +155,7 @@ class DPFVectorDouble(DPFVectorBase):
         self.dpf_vector_api.dpf_vector_double_commit(self, self.internal_data, self.internal_size, self.has_changed())
 
     def __del__(self):
-        if sys.is_finalizing() or getattr(_gate_capi, '_api_loading', False):
+        if sys is None or sys.is_finalizing() or getattr(_gate_capi, '_api_loading', False):
             return
         with suppress(Exception):
             if hasattr(self, "_array"):
@@ -220,7 +220,7 @@ class DPFVectorCustomType(DPFVectorBase):
         )
 
     def __del__(self):
-        if sys.is_finalizing() or getattr(_gate_capi, '_api_loading', False):
+        if sys is None or sys.is_finalizing() or getattr(_gate_capi, '_api_loading', False):
             return
         with suppress(Exception):
             if hasattr(self, "_array"):
@@ -245,7 +245,7 @@ class DPFVectorString(DPFVectorBase):
         return self._array
 
     def __del__(self):
-        if sys.is_finalizing() or getattr(_gate_capi, '_api_loading', False):
+        if sys is None or sys.is_finalizing() or getattr(_gate_capi, '_api_loading', False):
             return
         with suppress(Exception):
             if self._array:

--- a/src/ansys/dpf/gate/dpf_vector.py
+++ b/src/ansys/dpf/gate/dpf_vector.py
@@ -93,11 +93,11 @@ class DPFVectorBase:
         return self._modified and self.size > 0 # Updating is not necessary for an empty vector. Updating it can cause issue, see #2274
 
     def __del__(self):
-        if sys is None or sys.is_finalizing() or getattr(_gate_capi, '_api_loading', False):
+        if sys is None or sys.is_finalizing():
             return
         if hasattr(self, "_internal_obj"):
             with suppress(Exception):
-                self.dpf_vector_api.dpf_vector_delete(self)
+                _gate_capi._call_or_defer(self.dpf_vector_api.dpf_vector_delete, self)
 
 
 class DPFVectorInt(DPFVectorBase):
@@ -123,12 +123,17 @@ class DPFVectorInt(DPFVectorBase):
         self.dpf_vector_api.dpf_vector_int_commit(self, self.internal_data, self.internal_size, self.has_changed())
 
     def __del__(self):
-        if sys is None or sys.is_finalizing() or getattr(_gate_capi, '_api_loading', False):
+        if sys is None or sys.is_finalizing():
             return
         with suppress(Exception):
             if hasattr(self, "_array"):
-                self.dpf_vector_api.dpf_vector_int_free(self, self.internal_data, self.internal_size,
-                                                        self.has_changed())
+                _gate_capi._call_or_defer(
+                    self.dpf_vector_api.dpf_vector_int_free,
+                    self,
+                    self.internal_data,
+                    self.internal_size,
+                    self.has_changed(),
+                )
         super().__del__()
 
 
@@ -155,12 +160,17 @@ class DPFVectorDouble(DPFVectorBase):
         self.dpf_vector_api.dpf_vector_double_commit(self, self.internal_data, self.internal_size, self.has_changed())
 
     def __del__(self):
-        if sys is None or sys.is_finalizing() or getattr(_gate_capi, '_api_loading', False):
+        if sys is None or sys.is_finalizing():
             return
         with suppress(Exception):
             if hasattr(self, "_array"):
-                self.dpf_vector_api.dpf_vector_double_free(self, self.internal_data, self.internal_size,
-                                                           self.has_changed())
+                _gate_capi._call_or_defer(
+                    self.dpf_vector_api.dpf_vector_double_free,
+                    self,
+                    self.internal_data,
+                    self.internal_size,
+                    self.has_changed(),
+                )
         super().__del__()
 
 
@@ -220,12 +230,17 @@ class DPFVectorCustomType(DPFVectorBase):
         )
 
     def __del__(self):
-        if sys is None or sys.is_finalizing() or getattr(_gate_capi, '_api_loading', False):
+        if sys is None or sys.is_finalizing():
             return
         with suppress(Exception):
             if hasattr(self, "_array"):
-                self.dpf_vector_api.dpf_vector_char_free(self, self.internal_data, self.size * self.type.itemsize,
-                                                         self.has_changed())
+                _gate_capi._call_or_defer(
+                    self.dpf_vector_api.dpf_vector_char_free,
+                    self,
+                    self.internal_data,
+                    self.size * self.type.itemsize,
+                    self.has_changed(),
+                )
         super().__del__()
 
 
@@ -245,12 +260,17 @@ class DPFVectorString(DPFVectorBase):
         return self._array
 
     def __del__(self):
-        if sys is None or sys.is_finalizing() or getattr(_gate_capi, '_api_loading', False):
+        if sys is None or sys.is_finalizing():
             return
         with suppress(Exception):
             if self._array:
-                self.dpf_vector_api.dpf_vector_char_ptr_free(self, self.internal_data, self.internal_size,
-                                                             self.has_changed())
+                _gate_capi._call_or_defer(
+                    self.dpf_vector_api.dpf_vector_char_ptr_free,
+                    self,
+                    self.internal_data,
+                    self.internal_size,
+                    self.has_changed(),
+                )
         super().__del__()
 
     def __len__(self):

--- a/src/ansys/dpf/gate/generated/capi.py
+++ b/src/ansys/dpf/gate/generated/capi.py
@@ -1,4 +1,9 @@
 import ctypes
+from collections import deque
+import os
+import sys
+from threading import RLock
+
 #-------------------------------------------------------------------------------
 # Callbacks
 #-------------------------------------------------------------------------------
@@ -13,14 +18,70 @@ StringIntCallback = ctypes.CFUNCTYPE(None, ctypes.c_char_p, ctypes.c_int)
 IntIntCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_int)
 GenericCallBackType = ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_int, ctypes.c_char_p)
 
-# Flag indicating that load_api() is currently executing. Used by DPFVector.__del__
-# to avoid re-entrant C API calls during GC cycles that fire mid-initialization,
-# which can cause segfaults under Python 3.11 on Linux.
+# Flag indicating that load_api() is currently executing. Destructors defer native
+# cleanup while this flag is set because ctypes bindings are incomplete.
 _api_loading = False
+_api_path = None
+_api_load_lock = RLock()
+_deferred_cleanup = deque()
+
+
+def _call_or_defer(deleter, *args):
+	"""Call a native deleter now or queue it until API binding is complete."""
+	if sys is None or sys.is_finalizing():
+		return
+	with _api_load_lock:
+		if _api_loading:
+			_deferred_cleanup.append((deleter, args))
+			return
+		deleter(*args)
+
+
+def _drain_deferred_cleanup():
+	"""Run native cleanup queued during API binding."""
+	while True:
+		with _api_load_lock:
+			if not _deferred_cleanup:
+				return
+			deleter, args = _deferred_cleanup.popleft()
+		try:
+			deleter(*args)
+		except Exception:
+			# Destructors must not turn cleanup failures into load failures.
+			pass
+
 
 def load_api(path):
-	global dll, _api_loading
-	_api_loading = True
+	"""Load and bind the client API once per library path."""
+	global _api_loading, _api_path, dll
+	path = os.path.normcase(os.path.abspath(path))
+	with _api_load_lock:
+		if _api_path == path:
+			return
+		if _api_path is not None:
+			raise RuntimeError(
+				f"DPF client API already loaded from '{_api_path}', cannot load '{path}' in the same process"
+			)
+		previous_dll = globals().get("dll")
+		_api_loading = True
+		try:
+			_load_api(path)
+			_api_path = path
+		except Exception:
+			if previous_dll is None:
+				globals().pop("dll", None)
+			else:
+				dll = previous_dll
+			_deferred_cleanup.clear()
+			raise
+		finally:
+			_api_loading = False
+			if _api_path == path:
+				_drain_deferred_cleanup()
+
+
+def _load_api(path):
+	global dll
 	dll = ctypes.cdll.LoadLibrary(path)
 
 	#-------------------------------------------------------------------------------
@@ -5302,7 +5363,3 @@ def load_api(path):
 	if hasattr(dll, "FbsClient_StartOrGetThreadServer_on_client"):
 		dll.FbsClient_StartOrGetThreadServer_on_client.argtypes = (ctypes.c_void_p, ctypes.c_bool, ctypes.POINTER(ctypes.c_char), ctypes.c_int32, ctypes.POINTER(ctypes.c_char), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_wchar_p), )
 		dll.FbsClient_StartOrGetThreadServer_on_client.restype = ctypes.c_void_p
-
-
-	_api_loading = False
-

--- a/src/ansys/dpf/gate/object_handler.py
+++ b/src/ansys/dpf/gate/object_handler.py
@@ -1,5 +1,7 @@
 from contextlib import suppress
 
+from ansys.dpf.gate.generated import capi as _gate_capi
+
 
 class ObjHandler:
     def __init__(self, data_processing_api, internal_obj=None, server=None):
@@ -19,4 +21,7 @@ class ObjHandler:
     def __del__(self):
         with suppress(Exception):
             if hasattr(self, "_internal_obj") and not self.owned:
-                self.data_processing_api.data_processing_delete_shared_object(self)
+                _gate_capi._call_or_defer(
+                    self.data_processing_api.data_processing_delete_shared_object,
+                    self,
+                )

--- a/tests/test_dpf_vector.py
+++ b/tests/test_dpf_vector.py
@@ -25,7 +25,7 @@ import pytest
 
 from ansys.dpf import core as dpf
 from ansys.dpf.core import fields_factory
-from ansys.dpf.gate.dpf_vector import DPFVectorCustomType
+from ansys.dpf.gate import dpf_vector
 
 
 def test_perf_vec_setters(server_type):
@@ -108,4 +108,21 @@ def test_update_empty_dpf_vector_custom_type_field(server_type):
 
 def test_invalid_unitary_type_dpf_vector_custom_type(server_type):
     with pytest.raises(ValueError, match="DPFVectorCustomType: invalid unitary_type"):
-        DPFVectorCustomType(unitary_type=np.complex128)
+        dpf_vector.DPFVectorCustomType(unitary_type=np.complex128)
+
+
+@pytest.mark.parametrize(
+    "vector_type",
+    [
+        dpf_vector.DPFVectorBase,
+        dpf_vector.DPFVectorInt,
+        dpf_vector.DPFVectorDouble,
+        dpf_vector.DPFVectorCustomType,
+        dpf_vector.DPFVectorString,
+    ],
+)
+def test_dpf_vector_destructor_when_sys_is_cleared(monkeypatch, vector_type):
+    vector = object.__new__(vector_type)
+    monkeypatch.setattr(dpf_vector, "sys", None)
+
+    vector_type.__del__(vector)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -41,6 +41,7 @@ from ansys.dpf.core.misc import get_ansys_path
 from ansys.dpf.core.operator_specification import Specification
 from ansys.dpf.core.workflow_topology import WorkflowTopology
 from ansys.dpf.gate.generated import capi
+from ansys.dpf.core._cleanup import release_dpf_object
 import conftest
 from conftest import (
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_8_0,
@@ -67,6 +68,10 @@ def test_operator_destructor_during_api_loading(monkeypatch):
     capi._drain_deferred_cleanup()
     assert calls == ["operator-token"]
     del operator._deleter_func
+
+
+def test_release_dpf_object_without_deleter_is_noop():
+    release_dpf_object(object())
 
 
 def test_load_api_is_idempotent(monkeypatch, tmp_path):

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -51,10 +51,56 @@ HAS_AWP_ROOT212 = os.environ.get("AWP_ROOT212", False) is not False
 
 
 def test_operator_destructor_during_api_loading(monkeypatch):
+    calls = []
     operator = object.__new__(dpf_operator.Operator)
+    operator._deleter_func = (
+        lambda value: calls.append(value),
+        lambda value: "operator-token",
+    )
+    capi._deferred_cleanup.clear()
     monkeypatch.setattr(capi, "_api_loading", True)
 
     dpf_operator.Operator.__del__(operator)
+    assert calls == []
+
+    monkeypatch.setattr(capi, "_api_loading", False)
+    capi._drain_deferred_cleanup()
+    assert calls == ["operator-token"]
+    del operator._deleter_func
+
+
+def test_load_api_is_idempotent(monkeypatch, tmp_path):
+    loaded_paths = []
+    api_path = tmp_path / "DPFClientAPI.dll"
+    monkeypatch.setattr(capi, "_api_path", None)
+    monkeypatch.setattr(capi, "_load_api", lambda path: loaded_paths.append(path))
+
+    capi.load_api(api_path)
+    capi.load_api(api_path)
+
+    assert loaded_paths == [os.path.normcase(os.path.abspath(api_path))]
+    assert capi._api_loading is False
+
+
+def test_load_api_resets_loading_after_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(capi, "_api_path", None)
+
+    def fail_load(path):
+        raise RuntimeError("load failed")
+
+    monkeypatch.setattr(capi, "_load_api", fail_load)
+    with pytest.raises(RuntimeError, match="load failed"):
+        capi.load_api(tmp_path / "DPFClientAPI.dll")
+
+    assert capi._api_loading is False
+
+
+def test_load_api_rejects_different_path(monkeypatch, tmp_path):
+    loaded_path = os.path.normcase(os.path.abspath(tmp_path / "loaded.dll"))
+    monkeypatch.setattr(capi, "_api_path", loaded_path)
+
+    with pytest.raises(RuntimeError, match="already loaded"):
+        capi.load_api(tmp_path / "other.dll")
 
 
 def test_create_operator(server_type):

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -54,8 +54,13 @@ HAS_AWP_ROOT212 = os.environ.get("AWP_ROOT212", False) is not False
 def test_operator_destructor_during_api_loading(monkeypatch):
     calls = []
     operator = object.__new__(dpf_operator.Operator)
+
+    def local_capi_deleter(value):
+        calls.append(value)
+
+    local_capi_deleter.__module__ = "ansys.dpf.gate.generated.data_processing_capi"
     operator._deleter_func = (
-        lambda value: calls.append(value),
+        local_capi_deleter,
         lambda value: "operator-token",
     )
     capi._deferred_cleanup.clear()
@@ -67,6 +72,20 @@ def test_operator_destructor_during_api_loading(monkeypatch):
     monkeypatch.setattr(capi, "_api_loading", False)
     capi._drain_deferred_cleanup()
     assert calls == ["operator-token"]
+    del operator._deleter_func
+
+
+def test_release_dpf_object_calls_grpc_deleter_during_api_loading(monkeypatch):
+    calls = []
+    operator = object.__new__(dpf_operator.Operator)
+    operator._deleter_func = (lambda value: calls.append(value), lambda value: "grpc-token")
+    capi._deferred_cleanup.clear()
+    monkeypatch.setattr(capi, "_api_loading", True)
+
+    dpf_operator.Operator.__del__(operator)
+
+    assert calls == ["grpc-token"]
+    assert not capi._deferred_cleanup
     del operator._deleter_func
 
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -33,13 +33,14 @@ import numpy as np
 import pytest
 
 from ansys import dpf
-from ansys.dpf.core import errors, operators as ops
+from ansys.dpf.core import dpf_operator, errors, operators as ops
 from ansys.dpf.core.check_version import server_meet_version
 from ansys.dpf.core.common import derived_class_name_to_type, record_derived_class
 from ansys.dpf.core.custom_container_base import CustomContainerBase
 from ansys.dpf.core.misc import get_ansys_path
 from ansys.dpf.core.operator_specification import Specification
 from ansys.dpf.core.workflow_topology import WorkflowTopology
+from ansys.dpf.gate.generated import capi
 import conftest
 from conftest import (
     SERVERS_VERSION_GREATER_THAN_OR_EQUAL_TO_8_0,
@@ -47,6 +48,13 @@ from conftest import (
 
 # Check for ANSYS installation env var
 HAS_AWP_ROOT212 = os.environ.get("AWP_ROOT212", False) is not False
+
+
+def test_operator_destructor_during_api_loading(monkeypatch):
+    operator = object.__new__(dpf_operator.Operator)
+    monkeypatch.setattr(capi, "_api_loading", True)
+
+    dpf_operator.Operator.__del__(operator)
 
 
 def test_create_operator(server_type):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -245,7 +245,7 @@ def test_docker_busy_port(remote_config_server_type, clean_up):
     platform.system() == "Linux" and platform.python_version().startswith("3.7"),
     reason="Known failure in the GitHub pipeline for 3.7 on Ubuntu",
 )
-def test_shutting_down_when_deleted_legacy():
+def test_shutting_down_when_explicitly_shutdown_legacy():
     num_dpf_exe = 0
     for proc in psutil.process_iter():
         if "Ans.Dpf.Grpc" in proc.name():
@@ -257,7 +257,8 @@ def test_shutting_down_when_deleted_legacy():
             "from ansys.dpf import core as dpf;"
             "from ansys.dpf.core import examples;"
             "dpf.SERVER_CONFIGURATION = dpf.server_factory.AvailableServerConfigs.LegacyGrpcServer;"
-            "model = dpf.Model(examples.find_static_rst());",
+            "model = dpf.Model(examples.find_static_rst());"
+            "dpf.SERVER.shutdown();",
         ]
     )
     time.sleep(2.0)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -22,6 +22,7 @@
 
 import os
 import platform
+import gc
 import subprocess
 import sys
 import time
@@ -267,7 +268,7 @@ def test_shutting_down_when_deleted_legacy():
     assert num_dpf_exe >= new_num_dpf_exe
 
 
-def test_shutting_down_when_deleted():
+def test_shutting_down_when_explicitly_shutdown():
     num_dpf_exe = 0
     for proc in psutil.process_iter():
         if "Ans.Dpf.Grpc" in proc.name():
@@ -279,7 +280,8 @@ def test_shutting_down_when_deleted():
             "from ansys.dpf import core as dpf;"
             "from ansys.dpf.core import examples;"
             "dpf.SERVER_CONFIGURATION = dpf.server_factory.AvailableServerConfigs.GrpcServer;"
-            "model = dpf.Model(examples.find_static_rst());",
+            "model = dpf.Model(examples.find_static_rst());"
+            "dpf.SERVER.shutdown();",
         ]
     )
     time.sleep(2.0)
@@ -348,6 +350,8 @@ def test_start_after_shutting_down_server():
         config=dpf.core.AvailableServerConfigs.GrpcServer, as_global=False
     )
     remote_server.shutdown()
+    del remote_server
+    gc.collect()
 
     time.sleep(2.0)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -69,6 +69,14 @@ server_configs, server_configs_names = remove_none_available_config(
 )
 
 
+@pytest.mark.parametrize("server_type", [server_types.GrpcServer, server_types.LegacyGrpcServer])
+def test_server_destructor_when_sys_is_cleared(monkeypatch, server_type):
+    server_object = object.__new__(server_type)
+    monkeypatch.setattr(server_types, "sys", None)
+
+    server_type.__del__(server_object)
+
+
 @pytest.fixture(autouse=False, scope="function")
 def clean_up(request):
     """Count servers once we are finished."""


### PR DESCRIPTION
## Summary
- Make DPF native cleanup safe while the client C API is loading and during interpreter shutdown.
- Make same-path client API loading idempotent and serialize binding initialization.
- Defer generated local-CAPI deleters during incomplete ctypes binding and drain them afterward.
- Keep gRPC deleters synchronous during local API loading because their stubs are already initialized.
- Centralize standard `_deleter_func` cleanup in `ansys.dpf.core._cleanup.release_dpf_object`.
- Preserve custom cleanup ordering for vectors, sessions, local wrappers, handlers, and servers.
- Guard `CServer` and `LegacyGrpcServer` teardown before session deletion or native shutdown during interpreter finalization.
- Update gRPC and legacy gRPC lifecycle tests to perform explicit shutdown.

## Root causes addressed
- Python 3.10 can clear `sys` while DPF destructors run during interpreter shutdown.
- Python garbage collection can run while `capi.load_api()` is binding ctypes functions, making re-entrant local C API cleanup unsafe.
- Deferring gRPC RPC deleters during local API loading could overlap multi-server gRPC lifecycle and trigger `thread_manager.cc` aborts. gRPC cleanup now remains synchronous.
- Implicit destructor shutdown is unavailable once interpreter finalization begins; lifecycle tests now make ownership explicit.

## Validation
- Full `tests/test_remote_operator.py`: 3 passed against the supplied 2027 R1 standalone runtime.
- Focused server lifecycle tests passed against the supplied standalone runtime.
- Python 3.10 compilation passed for modified source and tests.
- Direct deferred-cleanup and partial-initialization harnesses passed.
- Repository pre-commit hooks passed: Ruff, Ruff format, codespell, conflict checks, debug statement checks, Bandit, and license validation.
- `git diff --check` passed.
- Full pytest remains environment-dependent; the local tox environment lacks the previously expected `ansys.dpf.server_2026_1_pre1` package.