### PR TITLE
ci(test): Disable a test on Docker

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -327,6 +327,7 @@ def test_connect_to_remote_server(remote_config_server_type):
     # assert server.config == remote_config_server_type
 
 
+@pytest.mark.skipif(running_docker, reason="Unstable on Docker")
 def test_go_away_server():
     for _ in range(0, 5):
         s = start_local_server(config=dpf.core.AvailableServerConfigs.GrpcServer, as_global=False)


### PR DESCRIPTION
Test `test_server/test_go_away_server` has become very unstable in Docker. After investigation, it turns out that it has been failing silently in the past (see [this](https://github.com/ansys/pydpf-core/actions/runs/34121378557/job/101767992883#step:20:89), [this](https://github.com/ansys/pydpf-core/actions/runs/34096394087/job/101684280669#step:20:89) or [this](https://github.com/ansys/pydpf-core/actions/runs/33766077897/job/100954292255#step:20:87)). The failures are now explicit and diferent (see [this](https://github.com/ansys/pydpf-core/actions/runs/34234211683/job/102366677317?pr=3441#step:20:341)).

The test is disabled to be able to run pipelines and bug #3444 is created to track its fix.