### PR TITLE
docs(tutorials): explain DataSources workflows

### DIFF
--- a/doc/sphinx_gallery_examples/03-harmonic_analyses/01-modal_superposition.py
+++ b/doc/sphinx_gallery_examples/03-harmonic_analyses/01-modal_superposition.py
@@ -33,6 +33,11 @@ a structure under given boundary conditions in a range of frequencies.
 Doing this expansion "on demand" in DPF instead of in the solver
 reduces the size of the result files.
 
+.. seealso::
+
+    :ref:`ref_tutorials_import_data_data_sources_upstream`
+        Learn how to connect downstream and upstream DataSources objects.
+
 """
 
 from ansys.dpf import core as dpf

--- a/doc/sphinx_gallery_tutorials/import_data/GALLERY_HEADER.rst
+++ b/doc/sphinx_gallery_tutorials/import_data/GALLERY_HEADER.rst
@@ -29,6 +29,20 @@ from simulation result files.
        +++
        :bdg-mapdl:`MAPDL` :bdg-lsdyna:`LS-DYNA` :bdg-fluent:`FLUENT` :bdg-cfx:`CFX`
 
+    .. grid-item-card:: Build and use a DataSources object
+       :link: ref_tutorials_import_data_data_sources_basics
+       :link-type: ref
+       :text-align: center
+
+       Learn how to register result files and pass DataSources to a Model or operator.
+
+    .. grid-item-card:: Connect DataSources for multi-analysis results
+       :link: ref_tutorials_import_data_data_sources_upstream
+       :link-type: ref
+       :text-align: center
+
+       Learn when to attach files directly and when to connect an upstream DataSources.
+
     .. grid-item-card:: Extract and explore results metadata
        :link: ref_tutorials_extract_and_explore_results_metadata
        :link-type: ref

--- a/doc/sphinx_gallery_tutorials/import_data/data_sources_basics.py
+++ b/doc/sphinx_gallery_tutorials/import_data/data_sources_basics.py
@@ -1,0 +1,127 @@
+# Copyright (C) 2020 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# _order: 7
+"""
+.. _ref_tutorials_import_data_data_sources_basics:
+
+Build and use a DataSources object
+===================================
+
+Learn how to describe result files to DPF with a |DataSources| object.
+
+|DataSources| is the container that tells DPF which files contain the data to
+read. This tutorial shows how to register a main result file, attach a
+secondary file from the same analysis, and pass the object to a |Model| or an
+individual result operator.
+
+When a file extension is ambiguous or has no extension, provide an explicit
+file key. For distributed result files, provide a domain ID as well. When files
+belong to different analyses, use an upstream |DataSources| object instead of
+adding every file to one flat collection.
+
+.. seealso::
+
+    :ref:`ref_tutorials_import_data_data_sources_upstream`
+        Learn how to connect DataSources objects for multi-analysis workflows.
+"""
+###############################################################################
+# Import the PyDPF-Core modules
+# -----------------------------
+#
+# Import the DPF API, result operators, and example-file helpers.
+
+from ansys.dpf import core as dpf
+from ansys.dpf.core import examples, operators as ops
+
+###############################################################################
+# Register a main result file
+# ---------------------------
+#
+# A DataSources object represents the files that make up one analysis. The
+# constructor can register the main result file immediately. The explicit
+# ``d3plot`` key selects the LS-DYNA result reader because this file has no
+# conventional result extension.
+
+# Download a result file and its accessory units file
+result_file_paths = examples.download_d3plot_beam()
+main_result_file = result_file_paths[0]
+units_file = result_file_paths[3]
+
+# Create the DataSources object with its main result file
+my_data_sources = dpf.DataSources(result_path=main_result_file, key="d3plot")
+
+###############################################################################
+# Add a secondary file from the same analysis
+# --------------------------------------------
+#
+# Secondary files contain supporting information that is not stored in the main
+# result file. Attach them with ``add_file_path()`` and use their file key when
+# the extension must be specified explicitly.
+
+# Add the units file belonging to the same analysis
+my_data_sources.add_file_path(filepath=units_file, key="actunits")
+
+# Inspect the main result key and its registered path
+print("Main result key:", my_data_sources.result_key)
+print("Main result files:", my_data_sources.result_files)
+
+###############################################################################
+# Give DataSources to a Model
+# ---------------------------
+#
+# Pass the DataSources object to a Model when you want DPF to expose common
+# metadata, mesh, and result helpers for the analysis.
+
+# Create a Model from the DataSources object
+my_model = dpf.Model(data_sources=my_data_sources)
+print("Model:", my_model)
+
+###############################################################################
+# Give DataSources to an operator
+# -------------------------------
+#
+# You can also connect the same DataSources object directly to an operator. This
+# is useful when you need one focused result without creating a full Model.
+
+# Create a displacement operator and connect its data source input
+displacement_op = ops.result.displacement()
+displacement_op.inputs.data_sources.connect(my_data_sources)
+displacement_fc = displacement_op.outputs.fields_container()
+print("Displacement fields:", displacement_fc)
+
+###############################################################################
+# Use an explicit key and domain IDs
+# ----------------------------------
+#
+# A key identifies which reader should interpret a file. A domain ID identifies
+# which part of a distributed solve produced a file. Set both when a result set
+# is split across domain-specific files.
+
+# Download two domain result files
+domain_files = examples.download_distributed_files()
+
+# Register one result file per domain with an explicit key
+distributed_data_sources = dpf.DataSources()
+distributed_data_sources.set_domain_result_file_path(path=domain_files[0], key="rst", domain_id=0)
+distributed_data_sources.set_domain_result_file_path(path=domain_files[1], key="rst", domain_id=1)
+print("Distributed DataSources:", distributed_data_sources)

--- a/doc/sphinx_gallery_tutorials/import_data/data_sources_upstream.py
+++ b/doc/sphinx_gallery_tutorials/import_data/data_sources_upstream.py
@@ -1,0 +1,127 @@
+# Copyright (C) 2020 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# _order: 8
+"""
+.. _ref_tutorials_import_data_data_sources_upstream:
+
+Connect DataSources for multi-analysis results
+================================================
+
+Learn when to attach files directly and when to connect an upstream |DataSources|.
+
+A |DataSources| object is a set of files from one analysis. An upstream
+|DataSources| represents a prior analysis whose results are needed by a
+downstream analysis. This distinction is important for modal superposition
+(MSUP), where a harmonic response uses a modal result from an earlier analysis.
+
+This tutorial shows the flat pattern that users often try first, the correct
+upstream chain, and the special case where the downstream harmonic working
+directory also contains a ``.mode`` restart file.
+
+.. seealso::
+
+    :ref:`ref_tutorials_import_data_data_sources_basics`
+        Learn the DataSources basics before connecting analyses.
+    :ref:`ref_msup`
+        See the existing MSUP example using the same upstream mechanism.
+"""
+###############################################################################
+# Download the MSUP result files
+# ------------------------------
+#
+# The example helper returns one harmonic response file and the files from its
+# upstream modal analysis.
+
+from ansys.dpf import core as dpf
+from ansys.dpf.core import examples
+
+# Download an MSUP result set that can run in CI
+msup_files = examples.download_msup_files_to_dict()
+
+###############################################################################
+# The flat pattern to avoid
+# -------------------------
+#
+# ``add_file_path()`` groups files that belong to one analysis. Adding the
+# modal files directly to the harmonic DataSources loses the relationship
+# between the downstream harmonic analysis and its upstream modal analysis.
+# Keep this pattern as a reference only; do not use it to create the Model.
+
+# This is the flat pattern users often try first
+flat_data_sources = dpf.DataSources()
+flat_data_sources.set_result_file_path(filepath=msup_files["rfrq"], key="rfrq")
+flat_data_sources.add_file_path(filepath=msup_files["mode"], key="mode")
+flat_data_sources.add_file_path(filepath=msup_files["rst"], key="rst")
+
+###############################################################################
+# Build the upstream relationship
+# -------------------------------
+#
+# Use ``add_file_path()`` for files from one analysis. Use ``add_upstream()``
+# when the files come from a prior analysis that the downstream result needs.
+
+# Create the downstream harmonic DataSources
+downstream_data_sources = dpf.DataSources(result_path=msup_files["rfrq"], key="rfrq")
+
+# Create the upstream modal DataSources
+upstream_data_sources = dpf.DataSources(result_path=msup_files["mode"], key="mode")
+upstream_data_sources.add_file_path(filepath=msup_files["rst"], key="rst")
+
+# Connect the modal analysis as upstream data for the harmonic analysis
+downstream_data_sources.add_upstream(upstream_data_sources=upstream_data_sources)
+
+###############################################################################
+# Evaluate a harmonic result
+# --------------------------
+#
+# After the relationship is defined, use the downstream DataSources with a
+# Model. DPF reads the harmonic response and expands it with the upstream mode
+# shapes using the same result request syntax as other analyses.
+
+# Create a Model from the downstream DataSources
+my_model = dpf.Model(data_sources=downstream_data_sources)
+
+# Evaluate displacement for every harmonic frequency
+displacement_fc = my_model.results.displacement.on_all_time_freqs.eval()
+print("Expanded displacement:", displacement_fc)
+
+###############################################################################
+# Handle a modal restart file in the downstream analysis
+# -------------------------------------------------------
+#
+# A modal restart in a harmonic analysis can produce two ``.mode`` files: the
+# upstream modal file and another ``.mode`` file in the downstream harmonic
+# working directory. The downstream file belongs to the downstream
+# DataSources, while the prior-analysis files remain in the upstream object.
+#
+# The download helper used above contains only one ``.mode`` file, so the
+# following guarded snippet shows the API call without inventing a second test
+# asset. In a Mechanical workflow, replace the path with the downstream
+# working-directory file before evaluating the Model.
+
+# The downstream restart mode file belongs to the downstream DataSources
+harmonic_restart_mode_path = "path/to/harmonic-working-directory/file.mode"
+# downstream_data_sources.add_file_path(
+#     filepath=harmonic_restart_mode_path,
+#     key="mode",
+# )

--- a/src/ansys/dpf/core/data_sources.py
+++ b/src/ansys/dpf/core/data_sources.py
@@ -80,6 +80,11 @@ class DataSources:
     >>> my_data_sources.result_files
     ['file.rst']
 
+    .. seealso::
+
+        :ref:`ref_tutorials_import_data_data_sources_basics`
+            Learn how to build and use DataSources objects.
+
     """
 
     def __init__(


### PR DESCRIPTION
﻿## Summary

- Add a beginner tutorial for registering result files, support files, explicit file keys, and distributed domains.
- Add an upstream/downstream tutorial for multi-analysis result sets and modal superposition.
- Link the DataSources API documentation source and the modal superposition example to the new tutorial.

## Validation

- Executed both tutorial scripts against cached example result files.
- Passed Python compilation, whitespace checks, and repository pre-commit checks.
- Static Markdown code-block and relative-link checks passed.
- Full Sphinx HTML build was not run because Sphinx and tox are unavailable in the environment.
