### PR TITLE
fix: guard Support cleanup before native initialization

### DIFF
--- a/src/ansys/dpf/core/_cleanup.py
+++ b/src/ansys/dpf/core/_cleanup.py
@@ -40,6 +40,8 @@ def release_dpf_object(obj):
         deleter = getattr(obj, "_deleter_func", None)
         if deleter is None:
             return
+        if getattr(obj, "_internal_obj", None) is None:
+            return
         native_obj = deleter[1](obj)
         if native_obj is not None:
             if getattr(_gate_capi, "_api_loading", False) and not _is_local_capi_deleter(

--- a/src/ansys/dpf/core/support.py
+++ b/src/ansys/dpf/core/support.py
@@ -74,6 +74,8 @@ class Support:
     """
 
     def __init__(self, support, server=None):
+        self._internal_obj = None
+
         # step 1: get server
         self._server = server_module.get_or_create_server(
             support._server if isinstance(support, Support) else server

--- a/tests/test_genericsupport.py
+++ b/tests/test_genericsupport.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 from ansys.dpf import core as dpf
+from ansys.dpf.core.support import Support
 
 
 def test_set_get_generic_support(server_type):
@@ -51,3 +52,17 @@ def test_set_get_generic_support(server_type):
     assert field is None
     field = support.prop_field_support_by_property("miscibility")
     assert isinstance(field, dpf.PropertyField)
+
+
+def test_support_destructor_without_native_object():
+    support = object.__new__(Support)
+    deleter_called = False
+
+    def deleter(value):
+        nonlocal deleter_called
+        deleter_called = True
+
+    support._deleter_func = (deleter, lambda value: value)
+
+    Support.__del__(support)
+    assert not deleter_called


### PR DESCRIPTION
## Description
Prevent partially initialized Support objects from invoking native cleanup before
`_internal_obj` exists.

Initialize the native handle invariant before Support API setup and add a
defensive cleanup guard with regression coverage.

## Related issue
Fixes #3425

## Validation
- Focused regression test passed
- Pre-commit hooks passed